### PR TITLE
ppmongo example doc link fix

### DIFF
--- a/doc/plugin_guide.md
+++ b/doc/plugin_guide.md
@@ -863,7 +863,7 @@ func mongodb(w http.ResponseWriter, r *http.Request) {
     ...
 }
 ```
-[Full Example Source](/plugin/logrus/example/logrus_example.go)
+[Full Example Source](/plugin/mongodriver/example/mongo_example.go)
 
 ## ppmysql
 This package instruments the mysql driver calls. 


### PR DESCRIPTION
Hi, pinpoint-apm team.

I'm glad to hear that the official version of pinpoint go agent  has been released!
While reading the guide document, I corrected it because there was an incorrect link in ppmongo example.

Thanks.