### PR TITLE
[#48] fix handler name mapping from echo plugins

### DIFF
--- a/plugin/echo/echo.go
+++ b/plugin/echo/echo.go
@@ -30,7 +30,7 @@ var (
 func makeHandlerNameMap(c echo.Context) {
 	handlerNameMap = make(map[string]string, 0)
 	for _, r := range c.Echo().Routes() {
-		handlerNameMap[r.Path] = r.Name + "()"
+		handlerNameMap[r.Method+r.Path] = r.Name + "()"
 	}
 }
 
@@ -60,7 +60,7 @@ func Middleware() echo.MiddlewareFunc {
 			once.Do(func() {
 				makeHandlerNameMap(c)
 			})
-			if handlerName, ok := handlerNameMap[c.Path()]; ok {
+			if handlerName, ok := handlerNameMap[req.Method+c.Path()]; ok {
 				tracer.NewSpanEvent(handlerName)
 			} else {
 				tracer.NewSpanEvent("echo.HandlerFunc()")

--- a/plugin/echo/echo_test.go
+++ b/plugin/echo/echo_test.go
@@ -1,0 +1,31 @@
+package ppecho
+
+import (
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func handler1(c echo.Context) error { return c.String(http.StatusOK, "hello-get") }
+func handler2(c echo.Context) error { return c.String(http.StatusOK, "hello-post") }
+
+func Test_makeHandlerNameMap(t *testing.T) {
+	t.Run("new handlerNameMap", func(t *testing.T) {
+		e := echo.New()
+
+		e.GET("/hello", handler1)
+		e.POST("/hello", handler2)
+
+		req := httptest.NewRequest(http.MethodPost, "/hello", nil)
+		rec := httptest.NewRecorder()
+
+		c := e.NewContext(req, rec)
+		makeHandlerNameMap(c)
+
+		assert.Equal(t, 2, len(handlerNameMap))
+		assert.Equal(t, "github.com/pinpoint-apm/pinpoint-go-agent/plugin/echo.handler1()", handlerNameMap["GET/hello"])
+		assert.Equal(t, "github.com/pinpoint-apm/pinpoint-go-agent/plugin/echo.handler2()", handlerNameMap["POST/hello"])
+	})
+}

--- a/plugin/echov4/echov4.go
+++ b/plugin/echov4/echov4.go
@@ -30,7 +30,7 @@ var (
 func makeHandlerNameMap(c echo.Context) {
 	handlerNameMap = make(map[string]string, 0)
 	for _, r := range c.Echo().Routes() {
-		handlerNameMap[r.Path] = r.Name + "()"
+		handlerNameMap[r.Method+r.Path] = r.Name + "()"
 	}
 }
 
@@ -57,10 +57,7 @@ func Middleware() echo.MiddlewareFunc {
 				}
 			}()
 
-			once.Do(func() {
-				makeHandlerNameMap(c)
-			})
-			if handlerName, ok := handlerNameMap[c.Path()]; ok {
+			if handlerName, ok := handlerNameMap[req.Method+c.Path()]; ok {
 				tracer.NewSpanEvent(handlerName)
 			} else {
 				tracer.NewSpanEvent("echo.HandlerFunc()")

--- a/plugin/echov4/echov4_test.go
+++ b/plugin/echov4/echov4_test.go
@@ -1,0 +1,31 @@
+package ppechov4
+
+import (
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func handler1(c echo.Context) error { return c.String(http.StatusOK, "hello-get") }
+func handler2(c echo.Context) error { return c.String(http.StatusOK, "hello-post") }
+
+func Test_makeHandlerNameMap(t *testing.T) {
+	t.Run("new handlerNameMap", func(t *testing.T) {
+		e := echo.New()
+
+		e.GET("/hello", handler1)
+		e.POST("/hello", handler2)
+
+		req := httptest.NewRequest(http.MethodPost, "/hello", nil)
+		rec := httptest.NewRecorder()
+
+		c := e.NewContext(req, rec)
+		makeHandlerNameMap(c)
+
+		assert.Equal(t, 2, len(handlerNameMap))
+		assert.Equal(t, "github.com/pinpoint-apm/pinpoint-go-agent/plugin/echov4.handler1()", handlerNameMap["GET/hello"])
+		assert.Equal(t, "github.com/pinpoint-apm/pinpoint-go-agent/plugin/echov4.handler2()", handlerNameMap["POST/hello"])
+	})
+}


### PR DESCRIPTION
# Issue
fix https://github.com/pinpoint-apm/pinpoint-go-agent/issues/48

# Description
Handler name map from echo plugins should check the method since the path can be duplicated.