### PR TITLE
feat: guard log level

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -3,6 +3,7 @@ package pinpoint
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"math"
 	"math/rand"
 	"net"
@@ -574,7 +575,11 @@ func (s *spanStream) sendSpan(span *span) error {
 		gspan = makePSpan(span)
 	}
 
-	Log("grpc").Tracef("PSpanMessage: %s", gspan.String())
+	if Log("grpc").extraLogger.IsLevelEnabled(logrus.DebugLevel) {
+		Log("grpc").Debugf("PSpanMessage: %s", gspan.String())
+	} else {
+		Log("grpc").Infof("success to make PSpanMessage")
+	}
 	return sendStreamWithTimeout(func() error { return s.stream.Send(gspan) }, sendStreamTimeOut, "span")
 }
 


### PR DESCRIPTION
Log("grpc")TraceOf("PSpanMessage: %s", gspan.String()) this line happens odd errors sometime.
And also charging bunch of resources...  
We have to guard log level. 
@dwkang  Thanks