### PR TITLE
Fix URL stat status failure tracking

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -1325,6 +1325,10 @@ func makePEachUriStat(e *eachUrlStat) *pb.PEachUriStat {
 }
 
 func makePUriHistogram(h *urlStatHistogram) *pb.PUriHistogram {
+	if h == nil || h.isEmpty() {
+		return &pb.PUriHistogram{}
+	}
+
 	return &pb.PUriHistogram{
 		Total:     h.total,
 		Max:       h.max,

--- a/noop.go
+++ b/noop.go
@@ -47,6 +47,7 @@ type noopSpan struct {
 	goroutineId int64
 	withStats   bool
 	urlStat     *UrlStatEntry
+	statusErr   int
 
 	noopSe      noopSpanEvent
 	annotations noopAnnotation
@@ -79,7 +80,7 @@ func (span *noopSpan) EndSpan() {
 		elapsed := endTime.UnixMilli() - span.startTime.UnixMilli()
 		collectResponseTime(elapsed)
 		if span.urlStat != nil {
-			span.agent.enqueueUrlStat(&urlStat{entry: span.urlStat, endTime: endTime, elapsed: elapsed})
+			span.agent.enqueueUrlStat(&urlStat{entry: span.urlStat, endTime: endTime, elapsed: elapsed, statusErr: span.statusErr})
 		}
 	}
 }
@@ -135,7 +136,9 @@ func (span *noopSpan) SpanEvent() SpanEventRecorder {
 
 func (span *noopSpan) SetError(e error) {}
 
-func (span *noopSpan) SetFailure() {}
+func (span *noopSpan) SetFailure() {
+	span.statusErr = 1
+}
 
 func (span *noopSpan) SetServiceType(typ int32) {}
 

--- a/span.go
+++ b/span.go
@@ -61,6 +61,7 @@ type span struct {
 	operationName   string
 	flags           int
 	err             int
+	statusErr       int
 	errorFuncId     int32
 	errorString     string
 	recovered       bool
@@ -136,7 +137,7 @@ func (span *span) EndSpan() {
 	}
 
 	if span.urlStat != nil {
-		span.agent.enqueueUrlStat(&urlStat{entry: span.urlStat, endTime: endTime, elapsed: span.elapsed})
+		span.agent.enqueueUrlStat(&urlStat{entry: span.urlStat, endTime: endTime, elapsed: span.elapsed, statusErr: span.statusErr})
 	}
 }
 
@@ -414,6 +415,7 @@ func (span *span) SetError(e error) {
 
 func (span *span) SetFailure() {
 	span.err = 1
+	span.statusErr = 1
 }
 
 func (span *span) SetServiceType(typ int32) {

--- a/sql_util.go
+++ b/sql_util.go
@@ -29,7 +29,7 @@ func newSqlNormalizer(sql string) *sqlNormalizer {
 }
 
 func (s *sqlNormalizer) run() (string, string) {
-	numberTokenStartEnable := false
+	numberTokenStartEnable := true
 
 	for {
 		if ch := s.read(); ch == eof {

--- a/sql_util_test.go
+++ b/sql_util_test.go
@@ -1,0 +1,352 @@
+package pinpoint
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_sqlNormalizer_DefaultSqlNormalizerCases(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		normalized string
+		params     string
+	}{
+		{
+			name:       "complex literals",
+			sql:        "select * from table a = 1 and b=50 and c=? and d='11'",
+			normalized: "select * from table a = 0# and b=1# and c=? and d='2$'",
+			params:     "1,50,11",
+		},
+		{
+			name:       "negative literals",
+			sql:        "select * from table a = -1 and b=-50 and c=? and d='-11'",
+			normalized: "select * from table a = -0# and b=-1# and c=? and d='2$'",
+			params:     "1,50,-11",
+		},
+		{
+			name:       "positive literals",
+			sql:        "select * from table a = +1 and b=+50 and c=? and d='+11'",
+			normalized: "select * from table a = +0# and b=+1# and c=? and d='2$'",
+			params:     "1,50,+11",
+		},
+		{
+			name:       "comments around literals",
+			sql:        "select * from table a = 1/*test*/ and b=50/*test*/ and c=? and d='11'",
+			normalized: "select * from table a = 0#/*test*/ and b=1#/*test*/ and c=? and d='2$'",
+			params:     "1,50,11",
+		},
+		{
+			name:       "plain identifiers",
+			sql:        "select ZIPCODE,CITY from ZIPCODE",
+			normalized: "select ZIPCODE,CITY from ZIPCODE",
+		},
+		{
+			name:       "qualified identifiers",
+			sql:        "select a.ZIPCODE,a.CITY from ZIPCODE as a",
+			normalized: "select a.ZIPCODE,a.CITY from ZIPCODE as a",
+		},
+		{
+			name:       "projection number",
+			sql:        "select ZIPCODE,123 from ZIPCODE",
+			normalized: "select ZIPCODE,0# from ZIPCODE",
+			params:     "123",
+		},
+		{
+			name:       "subtraction expression",
+			sql:        "SELECT * from table a=123 and b='abc' and c=1-3",
+			normalized: "SELECT * from table a=0# and b='1$' and c=2#-3#",
+			params:     "123,abc,1,3",
+		},
+		{
+			name:       "function arguments",
+			sql:        "SYSTEM_RANGE(1, 10)",
+			normalized: "SYSTEM_RANGE(0#, 1#)",
+			params:     "1,10",
+		},
+		{
+			name:       "identifier with dot",
+			sql:        "test.abc",
+			normalized: "test.abc",
+		},
+		{
+			name:       "identifier with digits",
+			sql:        "test.abc123",
+			normalized: "test.abc123",
+		},
+		{
+			name:       "dot before digits",
+			sql:        "test.123",
+			normalized: "test.123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_NumberState(t *testing.T) {
+	tests := []struct {
+		sql        string
+		normalized string
+		params     string
+	}{
+		{"123", "0#", "123"},
+		{"-123", "-0#", "123"},
+		{"+123", "+0#", "123"},
+		{"1.23", "0#", "1.23"},
+		{"1.23.34", "0#", "1.23.34"},
+		{"123 456", "0# 1#", "123,456"},
+		{"1.23 4.56", "0# 1#", "1.23,4.56"},
+		{"1.23-4.56", "0#-1#", "1.23,4.56"},
+		{"1<2", "0#<1#", "1,2"},
+		{"1< 2", "0#< 1#", "1,2"},
+		{"(1< 2)", "(0#< 1#)", "1,2"},
+		{"-- 1.23", "-- 1.23", ""},
+		{"- -1.23", "- -0#", "1.23"},
+		{"--1.23", "--1.23", ""},
+		{"/* 1.23 */", "/* 1.23 */", ""},
+		{"/*1.23*/", "/*1.23*/", ""},
+		{"/* 1.23 \n*/", "/* 1.23 \n*/", ""},
+		{"test123", "test123", ""},
+		{"test_123", "test_123", ""},
+		{"test_ 123", "test_ 0#", "123"},
+		{"123tst", "0#tst", "123"},
+		{"1.23e", "0#", "1.23e"},
+		{"1.23E", "0#", "1.23E"},
+		{"1.4e-10", "0#-1#", "1.4e,10"},
+		{"123 ", "0# ", "123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_CommentState(t *testing.T) {
+	tests := []struct {
+		sql        string
+		normalized string
+		params     string
+	}{
+		{"--", "--", ""},
+		{"//", "//", ""},
+		{"--123", "--123", ""},
+		{"//123", "//123", ""},
+		{"--test", "--test", ""},
+		{"//test", "//test", ""},
+		{"--test\ntest", "--test\ntest", ""},
+		{"--test\t\n", "--test\t\n", ""},
+		{"--test\n123 test", "--test\n0# test", "123"},
+		{"/**/", "/**/", ""},
+		{"/* */", "/* */", ""},
+		{"/* */abc", "/* */abc", ""},
+		{"/* * */", "/* * */", ""},
+		{"/* abc", "/* abc", ""},
+		{"select * from table", "select * from table", ""},
+		{"/*", "/*", ""},
+		{"/*  ", "/*  ", ""},
+		{"/*  \n  ", "/*  \n  ", ""},
+		{"/* 'test' */", "/* 'test' */", ""},
+		{"/* 'test'' */", "/* 'test'' */", ""},
+		{"/* '' */", "/* '' */", ""},
+		{"/*  */ 123 */", "/*  */ 0# */", "123"},
+		{"' /* */'", "'0$'", " /* */"},
+	}
+
+	for _, tt := range tests {
+		t.Run(displayName(tt.sql), func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_SymbolState(t *testing.T) {
+	tests := []struct {
+		sql        string
+		normalized string
+		params     string
+	}{
+		{"''", "''", ""},
+		{"'abc'", "'0$'", "abc"},
+		{"'a''bc'", "'0$'", "a''bc"},
+		{"'a' 'bc'", "'0$' '1$'", "a,bc"},
+		{"'a''bc' 'a''bc'", "'0$' '1$'", "a''bc,a''bc"},
+		{"select * from table where a='a'", "select * from table where a='0$'", "a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sql, func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_SeparatorAndEmptyChar(t *testing.T) {
+	tests := []struct {
+		name       string
+		sql        string
+		normalized string
+		params     string
+	}{
+		{
+			name:       "numbers separated by comma",
+			sql:        "1234 456,7",
+			normalized: "0# 1#,2#",
+			params:     "1234,456,7",
+		},
+		{
+			name:       "string containing comma",
+			sql:        "'1234 456,7'",
+			normalized: "'0$'",
+			params:     "1234 456,,7",
+		},
+		{
+			name:       "string containing escaped quote and comma",
+			sql:        "'1234''456,7'",
+			normalized: "'0$'",
+			params:     "1234''456,,7",
+		},
+		{
+			name:       "adjacent string literals",
+			sql:        "'1234' '456,7'",
+			normalized: "'0$' '1$'",
+			params:     "1234,456,,7",
+		},
+		{
+			name:       "empty string literal is preserved",
+			sql:        "select u.user_no as userNo,ifnull(s.equipment,'') as equipment,ifnull(s.gender, '0') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no = ?",
+			normalized: "select u.user_no as userNo,ifnull(s.equipment,'') as equipment,ifnull(s.gender, '0$') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no = ?",
+			params:     "0",
+		},
+		{
+			name:       "mixed empty and non-empty strings",
+			sql:        "select u.user_no as userNo,ifnull(s.equipment,'test_str') as equipment,ifnull(s.gender, '0') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no != ''",
+			normalized: "select u.user_no as userNo,ifnull(s.equipment,'0$') as equipment,ifnull(s.gender, '1$') as gender from user u left join supply s on u.user_no = s.user_no where u.user_no != ''",
+			params:     "test_str,0",
+		},
+		{
+			name:       "concat with comma in string",
+			sql:        "select concat ('hello,', u.name, ?)as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no = '10010'",
+			normalized: "select concat ('0$', u.name, ?)as hello, u.user_no as userNo from user u where 1# = 2# and u.user_no = '3$'",
+			params:     "hello,,,1,1,10010",
+		},
+		{
+			name:       "concat with space string",
+			sql:        "select concat ('hello,', u.name, ' ')as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no != ''",
+			normalized: "select concat ('0$', u.name, '1$')as hello, u.user_no as userNo from user u where 2# = 3# and u.user_no != ''",
+			params:     "hello,,, ,1,1",
+		},
+		{
+			name:       "concat with age comparison",
+			sql:        "select concat ('hello,', u.name, 'zhangsan')as hello, u.user_no as userNo from user u where 1 = 1 and u.user_no != '' and u.age > 20",
+			normalized: "select concat ('0$', u.name, '1$')as hello, u.user_no as userNo from user u where 2# = 3# and u.user_no != '' and u.age > 4#",
+			params:     "hello,,,zhangsan,1,1,20",
+		},
+		{
+			name:       "nested select in concat",
+			sql:        "select concat ('pinpoint,', u.name, (select s.user_no from user s where s.user_no = '8888'))as hello, u.user_no as userNo from user u where 1 = 1 and u.habit != '2768' and u.age > 20",
+			normalized: "select concat ('0$', u.name, (select s.user_no from user s where s.user_no = '1$'))as hello, u.user_no as userNo from user u where 2# = 3# and u.habit != '4$' and u.age > 5#",
+			params:     "pinpoint,,,8888,1,1,2768,20",
+		},
+		{
+			name:       "ifnull query",
+			sql:        "SELECT n.order_logistics_id, MAX(IF(IFNULL(n.id, '') != '', '2', '0')) AS is_ts FROM t_e_shipping_note n WHERE IFNULL(n.delflag, '') <> '1' AND IFNULL(n.document_require, '0') = '2' GROUP BY n.order_logistics_id",
+			normalized: "SELECT n.order_logistics_id, MAX(IF(IFNULL(n.id, '') != '', '0$', '1$')) AS is_ts FROM t_e_shipping_note n WHERE IFNULL(n.delflag, '') <> '2$' AND IFNULL(n.document_require, '3$') = '4$' GROUP BY n.order_logistics_id",
+			params:     "2,0,1,0,2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_SequentialIndexes(t *testing.T) {
+	tests := []struct {
+		sql        string
+		normalized string
+		params     string
+	}{
+		{"123 345", "0# 1#", "123,345"},
+		{"123 345 'test'", "0# 1# '2$'", "123,345,test"},
+		{"1 2 3 4 5 6 7 8 9 10 11", "0# 1# 2# 3# 4# 5# 6# 7# 8# 9# 10#", "1,2,3,4,5,6,7,8,9,10,11"},
+	}
+
+	for _, tt := range tests {
+		t.Run(displayName(tt.sql), func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func Test_sqlNormalizer_PostgresPositionalParameter(t *testing.T) {
+	tests := []struct {
+		sql        string
+		normalized string
+		params     string
+	}{
+		{
+			sql:        "SELECT * FROM member WHERE user = 'Kim' AND id = $1 AND no = 10",
+			normalized: "SELECT * FROM member WHERE user = '0$' AND id = $1 AND no = 1#",
+			params:     "Kim,10",
+		},
+		{
+			sql:        "SELECT * FROM member WHERE id = $122309 AND no = 122309",
+			normalized: "SELECT * FROM member WHERE id = $122309 AND no = 0#",
+			params:     "122309",
+		},
+		{
+			sql:        "$value, 123",
+			normalized: "$value, 0#",
+			params:     "123",
+		},
+		{
+			sql:        "'$123', 123",
+			normalized: "'0$', 1#",
+			params:     "$123,123",
+		},
+		{
+			sql:        "$; 123",
+			normalized: "$; 0#",
+			params:     "123",
+		},
+		{
+			sql:        "$(123); 123",
+			normalized: "$(0#); 1#",
+			params:     "123,123",
+		},
+		{
+			sql:        "'$''123'",
+			normalized: "'0$'",
+			params:     "$''123",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(displayName(tt.sql), func(t *testing.T) {
+			assertNormalize(t, tt.sql, tt.normalized, tt.params)
+		})
+	}
+}
+
+func assertNormalize(t *testing.T, sql, normalized, params string) {
+	t.Helper()
+
+	actualNormalized, actualParams := newSqlNormalizer(sql).run()
+	assert.Equal(t, normalized, actualNormalized, "normalized sql")
+	assert.Equal(t, params, actualParams, "params")
+}
+
+func displayName(sql string) string {
+	return strings.ReplaceAll(sql, "\n", "\\n")
+}

--- a/url_stat.go
+++ b/url_stat.go
@@ -25,9 +25,10 @@ func (agent *agent) initUrlStat() {
 }
 
 type urlStat struct {
-	entry   *UrlStatEntry
-	endTime time.Time
-	elapsed int64
+	entry     *UrlStatEntry
+	endTime   time.Time
+	elapsed   int64
+	statusErr int
 }
 
 type urlStatSnapshot struct {
@@ -82,6 +83,10 @@ func (agent *agent) takeUrlStatSnapshot() *urlStatSnapshot {
 }
 
 func (snapshot *urlStatSnapshot) add(us *urlStat) {
+	if us.endTime.IsZero() {
+		return
+	}
+
 	var url string
 	if snapshot.config.urlStatWithMethod && us.entry.Method != "" {
 		url = us.entry.Method + " " + us.entry.Url
@@ -102,7 +107,7 @@ func (snapshot *urlStatSnapshot) add(us *urlStat) {
 	}
 
 	e.totalHistogram.add(us.elapsed)
-	if urlStatStatus(us.entry.Status) == urlStatusFail {
+	if urlStatStatus(us.statusErr) == urlStatusFail {
 		e.failedHistogram.add(us.elapsed)
 	}
 }
@@ -128,6 +133,15 @@ func (hg *urlStatHistogram) add(elapsed int64) {
 		hg.max = elapsed
 	}
 	hg.histogram[getBucket(elapsed)]++
+}
+
+func (hg *urlStatHistogram) isEmpty() bool {
+	for _, count := range hg.histogram {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
 }
 
 func getBucket(elapsed int64) int {
@@ -158,8 +172,8 @@ func (t tickClock) tick(tm time.Time) time.Time {
 	return tm.Truncate(t.interval)
 }
 
-func urlStatStatus(status int) int {
-	if status/100 < 4 {
+func urlStatStatus(statusErr int) int {
+	if statusErr == 0 {
 		return urlStatusSuccess
 	} else {
 		return urlStatusFail

--- a/url_stat_test.go
+++ b/url_stat_test.go
@@ -1,0 +1,289 @@
+package pinpoint
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_urlStatBucketLayoutFromJavaAgent(t *testing.T) {
+	assert.Equal(t, 0, urlStatBucketVersion)
+	assert.Equal(t, 8, urlStatBucketSize)
+	assert.Equal(t, 0, getBucket(1))
+
+	tests := []struct {
+		elapsed int64
+		bucket  int
+	}{
+		{elapsed: 0, bucket: 0},
+		{elapsed: 99, bucket: 0},
+		{elapsed: 100, bucket: 1},
+		{elapsed: 299, bucket: 1},
+		{elapsed: 300, bucket: 2},
+		{elapsed: 499, bucket: 2},
+		{elapsed: 500, bucket: 3},
+		{elapsed: 999, bucket: 3},
+		{elapsed: 1000, bucket: 4},
+		{elapsed: 2999, bucket: 4},
+		{elapsed: 3000, bucket: 5},
+		{elapsed: 4999, bucket: 5},
+		{elapsed: 5000, bucket: 6},
+		{elapsed: 7999, bucket: 6},
+		{elapsed: 8000, bucket: 7},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.bucket, getBucket(tt.elapsed), "elapsed=%d", tt.elapsed)
+	}
+}
+
+func Test_urlStatSnapshotKeepsAggregatingExistingPatternAtCapacity(t *testing.T) {
+	snapshot, endTime := newUrlStatTestSnapshot(1, false)
+
+	addTestUrlStat(snapshot, "/test", "", 0, 10, endTime)
+	addTestUrlStat(snapshot, "/test", "", 0, 20, endTime)
+	addTestUrlStat(snapshot, "/other", "", 0, 30, endTime)
+
+	stat := findEachUrlStat(t, snapshot, "/test", endTime)
+	assert.Len(t, snapshot.urlMap, 1)
+	assert.Equal(t, int32(2), histogramCount(stat.totalHistogram))
+	assert.Equal(t, int64(30), stat.totalHistogram.total)
+	assert.Equal(t, int64(20), stat.totalHistogram.max)
+}
+
+func Test_urlStatSnapshotAddPatternFromJavaAgent(t *testing.T) {
+	snapshot, endTime := newUrlStatTestSnapshot(10, false)
+
+	addTestUrlStat(snapshot, "pattern1", "", 0, 10, endTime)
+	addTestUrlStat(snapshot, "pattern1", "", 0, 20, endTime)
+	addTestUrlStat(snapshot, "pattern2", "", 0, 30, endTime)
+
+	assert.Len(t, snapshot.urlMap, 2)
+
+	pattern1 := findEachUrlStat(t, snapshot, "pattern1", endTime)
+	assert.Equal(t, int32(2), histogramCount(pattern1.totalHistogram))
+	assert.Equal(t, int64(30), pattern1.totalHistogram.total)
+	assert.Equal(t, int64(20), pattern1.totalHistogram.max)
+}
+
+func Test_urlStatSnapshotTransformsMethodLikeJavaAgent(t *testing.T) {
+	snapshot, endTime := newUrlStatTestSnapshot(10, true)
+
+	addTestUrlStat(snapshot, "/orders/{id}", "GET", 0, 90, endTime)
+	addTestUrlStat(snapshot, "/orders/{id}", "GET", 1, 110, endTime)
+	addTestUrlStat(snapshot, "/orders/{id}", "", 1, 300, endTime)
+
+	assert.Len(t, snapshot.urlMap, 2)
+
+	withMethod := findEachUrlStat(t, snapshot, "GET /orders/{id}", endTime)
+	assert.Equal(t, int32(2), histogramCount(withMethod.totalHistogram))
+	assert.Equal(t, int64(200), withMethod.totalHistogram.total)
+	assert.Equal(t, int64(110), withMethod.totalHistogram.max)
+	assert.Equal(t, int32(1), withMethod.totalHistogram.histogram[0])
+	assert.Equal(t, int32(1), withMethod.totalHistogram.histogram[1])
+	assert.Equal(t, int32(1), histogramCount(withMethod.failedHistogram))
+	assert.Equal(t, int64(110), withMethod.failedHistogram.total)
+
+	withoutMethod := findEachUrlStat(t, snapshot, "/orders/{id}", endTime)
+	assert.Equal(t, int32(1), histogramCount(withoutMethod.totalHistogram))
+	assert.Equal(t, int32(1), histogramCount(withoutMethod.failedHistogram))
+	assert.Equal(t, int64(300), withoutMethod.failedHistogram.total)
+}
+
+func Test_makePAgentUriStatConvertsLikeJavaAgentMapper(t *testing.T) {
+	snapshot, endTime := newUrlStatTestSnapshot(10, false)
+
+	samples := []urlStatSample{
+		{url: "/index.html", statusErr: 0, elapsed: 50},
+		{url: "/index.html", statusErr: 1, elapsed: 150},
+		{url: "/main", statusErr: 0, elapsed: 350},
+		{url: "/main", statusErr: 0, elapsed: 900},
+		{url: "/error", statusErr: 1, elapsed: 1200},
+		{url: "/error", statusErr: 1, elapsed: 6000},
+	}
+	expected := makeExpectedUrlStats(samples, endTime)
+	for _, sample := range samples {
+		addTestUrlStat(snapshot, sample.url, "", sample.statusErr, sample.elapsed, endTime)
+	}
+
+	agentUriStat := makePAgentUriStat(snapshot).GetAgentUriStat()
+
+	assert.Equal(t, int32(urlStatBucketVersion), agentUriStat.GetBucketVersion())
+	assert.Len(t, agentUriStat.GetEachUriStat(), len(expected))
+	for _, actual := range agentUriStat.GetEachUriStat() {
+		expectedStat, ok := expected[actual.GetUri()]
+		assert.True(t, ok, "unexpected uri=%s", actual.GetUri())
+		if !ok {
+			continue
+		}
+
+		assert.Equal(t, expectedStat.timestamp, actual.GetTimestamp())
+		assertUriHistogram(t, expectedStat.total, actual.GetTotalHistogram())
+		assertUriHistogram(t, expectedStat.failed, actual.GetFailedHistogram())
+	}
+}
+
+func Test_makePUriHistogramReturnsEmptyForNoSamplesLikeJavaAgentMapper(t *testing.T) {
+	histogram := makePUriHistogram(newStatHistogram())
+
+	assert.Equal(t, int64(0), histogram.GetTotal())
+	assert.Equal(t, int64(0), histogram.GetMax())
+	assert.Empty(t, histogram.GetHistogram())
+}
+
+func Test_urlStatSnapshotIgnoresZeroEndTimeLikeJavaAgent(t *testing.T) {
+	snapshot, _ := newUrlStatTestSnapshot(10, false)
+
+	addTestUrlStat(snapshot, "/zero", "", 0, 10, time.Time{})
+
+	assert.Empty(t, snapshot.urlMap)
+}
+
+func Test_urlStatFailureUsesStatusFailureOnly(t *testing.T) {
+	snapshot, endTime := newUrlStatTestSnapshot(10, false)
+
+	addTestUrlStat(snapshot, "/server-error-status", "", 0, 500, endTime)
+	addTestUrlStat(snapshot, "/status-error", "", 1, 200, endTime)
+
+	serverErrorStatus := findEachUrlStat(t, snapshot, "/server-error-status", endTime)
+	assert.Equal(t, int32(1), histogramCount(serverErrorStatus.totalHistogram))
+	assert.Equal(t, int32(0), histogramCount(serverErrorStatus.failedHistogram))
+
+	statusError := findEachUrlStat(t, snapshot, "/status-error", endTime)
+	assert.Equal(t, int32(1), histogramCount(statusError.totalHistogram))
+	assert.Equal(t, int32(1), histogramCount(statusError.failedHistogram))
+}
+
+func Test_spanStatusErrIsSetOnlyBySetFailure(t *testing.T) {
+	span := defaultSpan()
+	span.agent = newTestAgent(defaultConfig())
+
+	span.SetError(errors.New("application error"))
+	assert.Equal(t, 1, span.err)
+	assert.Equal(t, 0, span.statusErr)
+
+	span.SetFailure()
+	assert.Equal(t, 1, span.err)
+	assert.Equal(t, 1, span.statusErr)
+}
+
+type urlStatSample struct {
+	url       string
+	statusErr int
+	elapsed   int64
+}
+
+type expectedUrlStat struct {
+	timestamp int64
+	total     expectedUrlHistogram
+	failed    expectedUrlHistogram
+}
+
+type expectedUrlHistogram struct {
+	total     int64
+	max       int64
+	histogram []int32
+}
+
+func newUrlStatTestSnapshot(limit int, withMethod bool) (*urlStatSnapshot, time.Time) {
+	config := defaultConfig()
+	config.urlStatLimitSize = limit
+	config.urlStatWithMethod = withMethod
+	agent := newTestAgent(config)
+	clock = newTickClock(urlStatCollectInterval)
+
+	return agent.newUrlStatSnapshot(), time.Unix(1700000000, 123000000).UTC()
+}
+
+func addTestUrlStat(snapshot *urlStatSnapshot, url string, method string, statusErr int, elapsed int64, endTime time.Time) {
+	snapshot.add(&urlStat{
+		entry: &UrlStatEntry{
+			Url:    url,
+			Method: method,
+		},
+		endTime:   endTime,
+		elapsed:   elapsed,
+		statusErr: statusErr,
+	})
+}
+
+func findEachUrlStat(t *testing.T, snapshot *urlStatSnapshot, url string, endTime time.Time) *eachUrlStat {
+	t.Helper()
+
+	stat, ok := snapshot.urlMap[urlKey{url: url, tick: clock.tick(endTime)}]
+	assert.True(t, ok, "url=%s", url)
+	if !ok {
+		return nil
+	}
+	return stat
+}
+
+func histogramCount(histogram *urlStatHistogram) int32 {
+	var count int32
+	for _, bucketCount := range histogram.histogram {
+		count += bucketCount
+	}
+	return count
+}
+
+func makeExpectedUrlStats(samples []urlStatSample, endTime time.Time) map[string]*expectedUrlStat {
+	expected := make(map[string]*expectedUrlStat)
+	timestamp := clock.tick(endTime).UnixNano() / int64(time.Millisecond)
+
+	for _, sample := range samples {
+		stat := expected[sample.url]
+		if stat == nil {
+			stat = &expectedUrlStat{
+				timestamp: timestamp,
+				total:     newExpectedUrlHistogram(),
+				failed:    newExpectedUrlHistogram(),
+			}
+			expected[sample.url] = stat
+		}
+
+		stat.total.add(sample.elapsed)
+		if urlStatStatus(sample.statusErr) == urlStatusFail {
+			stat.failed.add(sample.elapsed)
+		}
+	}
+
+	return expected
+}
+
+func newExpectedUrlHistogram() expectedUrlHistogram {
+	return expectedUrlHistogram{
+		histogram: make([]int32, urlStatBucketSize),
+	}
+}
+
+func (histogram *expectedUrlHistogram) add(elapsed int64) {
+	histogram.total += elapsed
+	if histogram.max < elapsed {
+		histogram.max = elapsed
+	}
+	histogram.histogram[getBucket(elapsed)]++
+}
+
+func assertUriHistogram(t *testing.T, expected expectedUrlHistogram, actual *pb.PUriHistogram) {
+	t.Helper()
+
+	assert.Equal(t, expected.total, actual.GetTotal())
+	assert.Equal(t, expected.max, actual.GetMax())
+	if expected.isEmpty() {
+		assert.Empty(t, actual.GetHistogram())
+		return
+	}
+	assert.Equal(t, expected.histogram, actual.GetHistogram())
+}
+
+func (histogram expectedUrlHistogram) isEmpty() bool {
+	for _, count := range histogram.histogram {
+		if count != 0 {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary

- Add a separate `statusErr` field so URL stat failures are tied only to HTTP status failure handling.
- Pass `statusErr` from sampled and unsampled spans into URL stat aggregation.
- Keep existing URL/tick aggregation behavior at capacity while limiting new URL/tick entries.
- Align empty URL stat histogram protobuf mapping with the Java agent mapper.
- Add URL stat tests ported from the Java agent behavior.

## Tests

- `GOCACHE=/private/tmp/pinpoint-go-agent-gocache go test ./...`

Fixes #116