### PR TITLE
[#noissue] Make gRPC streaming backpressure flow-control aware

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -158,6 +158,24 @@ const (
 	grpcWriteBufferSize   = 1 * 1024 * 1024
 	grpcMaxMessageSize    = 4 * 1024 * 1024
 	grpcMaxHeaderListSize = 8 * 1024
+
+	// Flow-control backpressure tuning for the streaming send paths (span/stat).
+	//
+	// grpc-go's stream.Send() blocks until HTTP/2 flow control has window space
+	// for the message (or the stream breaks). A Send that stays blocked is the
+	// Go analog of the Java agent's stream.isReady()==false. Rather than tear the
+	// stream down on the first slow Send (the old 5s-timeout-then-recreate policy),
+	// the sender tolerates a window of sustained backpressure, mirroring the Java
+	// agent's SimpleStreamState(100, 5000): give up only after streamFailLimitCount
+	// not-ready probes spanning more than streamFailLimitTime.
+	//
+	// sendStreamReadyTimeout is how long we wait for an in-flight Send to make
+	// progress before counting one not-ready probe. It is sized so the count limit
+	// and the time limit are reached together (100 * 50ms ≈ 5s), so a continuously
+	// blocked stream is recreated after ~5s of backpressure, matching Java.
+	sendStreamReadyTimeout = 50 * time.Millisecond
+	streamFailLimitCount   = 100
+	streamFailLimitTime    = 5 * time.Second
 )
 
 var kacp = keepalive.ClientParameters{
@@ -617,6 +635,132 @@ func sendStreamWithTimeout(send func() error, timeout time.Duration, which strin
 	}
 }
 
+// streamState is a port of the Java agent's SimpleStreamState. It tracks a
+// rolling window of "not ready" (flow-control blocked) send probes and reports a
+// failure only once that window is both long enough (limitTime) and dense enough
+// (limitCount) to conclude the stream is no longer draining. A successful send
+// resets the window. It is accessed only from a stream's single sender path, so
+// it needs no synchronization.
+type streamState struct {
+	limitCount  int
+	limitTime   time.Duration
+	failCount   int
+	failureTime time.Time
+}
+
+func newStreamState() *streamState {
+	return &streamState{limitCount: streamFailLimitCount, limitTime: streamFailLimitTime}
+}
+
+func (s *streamState) init() {
+	s.failCount = 0
+	s.failureTime = time.Time{}
+}
+
+func (s *streamState) success() {
+	s.failCount = 0
+	s.failureTime = time.Time{}
+}
+
+func (s *streamState) fail() {
+	if s.failureTime.IsZero() {
+		s.failureTime = time.Now()
+	}
+	s.failCount++
+}
+
+func (s *streamState) isFailure() bool {
+	if s.failureTime.IsZero() {
+		return false
+	}
+	return time.Since(s.failureTime) > s.limitTime && s.failCount > s.limitCount
+}
+
+// streamSender owns a single long-lived goroutine that performs the blocking
+// stream.Send() for one stream. Replacing the previous goroutine-per-send model,
+// it lets the worker submit one send at a time and wait on it with a
+// backpressure-tolerance window instead of recreating the stream on the first
+// slow send. The goroutine lives exactly as long as its stream and is stopped by
+// close().
+type streamSender struct {
+	reqChan chan func() error
+	resChan chan error
+	done    chan struct{}
+	wg      sync.WaitGroup
+}
+
+func newStreamSender() *streamSender {
+	s := &streamSender{
+		reqChan: make(chan func() error),
+		resChan: make(chan error, 1),
+		done:    make(chan struct{}),
+	}
+	s.wg.Add(1)
+	go s.loop()
+	return s
+}
+
+func (s *streamSender) loop() {
+	defer s.wg.Done()
+	for {
+		select {
+		case send := <-s.reqChan:
+			// resChan is buffered (cap 1) and only one send is ever in flight,
+			// so this never blocks even if the worker has already given up on a
+			// slow send and stopped reading the result.
+			s.resChan <- send()
+		case <-s.done:
+			return
+		}
+	}
+}
+
+// send submits one blocking send to the sender goroutine and waits for it,
+// tolerating transient flow-control backpressure. While the send stays blocked
+// it records "not ready" probes against state; it returns a DeadlineExceeded
+// error only once the failure window is exceeded (sustained backpressure), a
+// real error when the send fails, or nil on success. The caller tears the stream
+// down on any non-nil error, which cancels the stream context and unblocks the
+// in-flight send.
+func (s *streamSender) send(send func() error, state *streamState, which string) error {
+	select {
+	case s.reqChan <- send:
+	case <-s.done:
+		return status.Errorf(codes.Unavailable, which+" stream sender closed")
+	}
+
+	t := acquireStreamTimer(sendStreamReadyTimeout)
+	defer releaseStreamTimer(t)
+
+	for {
+		select {
+		case err := <-s.resChan:
+			if err == nil {
+				state.success()
+			}
+			return err
+		case <-t.C:
+			state.fail()
+			if state.isFailure() {
+				return status.Errorf(codes.DeadlineExceeded, which+" stream.Send() - flow control blocked beyond failure window")
+			}
+			t.Reset(sendStreamReadyTimeout)
+		}
+	}
+}
+
+// close stops the sender goroutine. It must be called only when no send is in
+// flight: the worker reaches it after send() has returned (the error path has
+// already cancelled the stream) or after the queue is drained at shutdown, so
+// the goroutine is idle and exits promptly.
+func (s *streamSender) close() {
+	if s == nil {
+		return
+	}
+	close(s.done)
+	s.wg.Wait()
+}
+
 func waitUntilReady(grpcConn *grpc.ClientConn, timeout time.Duration, which string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -770,6 +914,8 @@ type spanGrpc struct {
 type spanStream struct {
 	stream pb.Span_SendSpanClient
 	cancel context.CancelFunc
+	sender *streamSender
+	state  *streamState
 }
 
 func newSpanGrpc(agent *agent) (*spanGrpc, error) {
@@ -806,7 +952,7 @@ func (spanGrpc *spanGrpc) newSpanStream() bool {
 		return false
 	}
 
-	spanGrpc.stream = &spanStream{stream, cancel}
+	spanGrpc.stream = &spanStream{stream: stream, cancel: cancel, sender: newStreamSender(), state: newStreamState()}
 	return true
 }
 
@@ -824,6 +970,9 @@ func (s *spanStream) close() {
 	}
 	defer s.cancel()
 
+	// Stop the sender goroutine before CloseAndRecv: SendMsg and CloseAndRecv
+	// must not run concurrently, and at this point no send is in flight.
+	s.sender.close()
 	sendStreamWithTimeout(
 		func() error {
 			_, err := s.stream.CloseAndRecv()
@@ -855,7 +1004,7 @@ func (s *spanStream) sendSpan(chunk *spanChunk) error {
 		Log("grpc").Tracef("PSpanMessage: %s", gspan.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(gspan) }, sendStreamTimeOut, "span")
+	err := s.sender.send(func() error { return s.stream.Send(gspan) }, s.state, "span")
 	if err != nil {
 		s.cancel()
 	}
@@ -1173,6 +1322,8 @@ type statGrpc struct {
 type statStream struct {
 	stream pb.Stat_SendAgentStatClient
 	cancel context.CancelFunc
+	sender *streamSender
+	state  *streamState
 }
 
 func newStatGrpc(agent *agent) (*statGrpc, error) {
@@ -1203,7 +1354,7 @@ func (statGrpc *statGrpc) newStatStream() bool {
 		return false
 	}
 
-	statGrpc.stream = &statStream{stream, cancel}
+	statGrpc.stream = &statStream{stream: stream, cancel: cancel, sender: newStreamSender(), state: newStreamState()}
 	return true
 }
 
@@ -1221,6 +1372,8 @@ func (s *statStream) close() {
 	}
 	defer s.cancel()
 
+	// Stop the sender goroutine before CloseAndRecv (see spanStream.close).
+	s.sender.close()
 	sendStreamWithTimeout(
 		func() error {
 			_, err := s.stream.CloseAndRecv()
@@ -1240,7 +1393,7 @@ func (s *statStream) sendStats(stats *pb.PStatMessage) error {
 		Log("grpc").Tracef("PStatMessage: %s", stats.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(stats) }, sendStreamTimeOut, "stat")
+	err := s.sender.send(func() error { return s.stream.Send(stats) }, s.state, "stat")
 	if err != nil {
 		s.cancel()
 	}

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func Test_agentGrpc_sendAgentInfo(t *testing.T) {
@@ -294,6 +296,62 @@ func newTestSpanChunk(agent *agent) *spanChunk {
 	span := defaultSpan()
 	span.agent = agent
 	return span.newEventChunk(true)
+}
+
+func Test_streamState_isFailure(t *testing.T) {
+	// Mirrors the Java SimpleStreamState contract: a failure is reported only
+	// once the window is both dense (> limitCount) and long (> limitTime).
+	s := &streamState{limitCount: 3, limitTime: 50 * time.Millisecond}
+
+	assert.False(t, s.isFailure(), "no fails yet")
+
+	for i := 0; i < 10; i++ {
+		s.fail()
+	}
+	assert.False(t, s.isFailure(), "count exceeded but time window not yet elapsed")
+
+	time.Sleep(60 * time.Millisecond)
+	assert.True(t, s.isFailure(), "count and time both exceeded")
+
+	// A success resets the window entirely.
+	s.success()
+	assert.False(t, s.isFailure(), "success clears the failure window")
+	s.fail()
+	assert.False(t, s.isFailure(), "single fail after reset is tolerated")
+}
+
+func Test_streamSender_toleratesTransientBlockThenSucceeds(t *testing.T) {
+	// A send that is briefly slow (longer than one not-ready probe) but well
+	// within the failure window must succeed without tearing down the stream.
+	sender := newStreamSender()
+	defer sender.close()
+	state := newStreamState()
+
+	err := sender.send(func() error {
+		time.Sleep(sendStreamReadyTimeout * 3)
+		return nil
+	}, state, "test")
+
+	assert.NoError(t, err, "transient slowness should be tolerated")
+	assert.False(t, state.isFailure(), "successful send resets the failure window")
+}
+
+func Test_streamSender_givesUpAfterFailureWindow(t *testing.T) {
+	// A send that stays blocked past the failure window returns DeadlineExceeded
+	// so the worker can recreate the stream. A small window keeps the test fast.
+	sender := newStreamSender()
+	defer sender.close()
+	state := &streamState{limitCount: 2, limitTime: 30 * time.Millisecond}
+
+	release := make(chan struct{})
+	err := sender.send(func() error {
+		<-release // stay blocked until the sender goroutine is told to unblock
+		return nil
+	}, state, "test")
+	close(release) // unblock the in-flight send so the sender goroutine can exit
+
+	assert.Error(t, err, "sustained backpressure should surface an error")
+	assert.Equal(t, codes.DeadlineExceeded, status.Code(err), "give-up uses DeadlineExceeded")
 }
 
 func Test_statStream_sendStatRetry(t *testing.T) {


### PR DESCRIPTION
## Overview

Reworks the span/stat gRPC **streaming** send paths to be flow-control (backpressure) aware and tolerant of transient slowness, bringing the Go agent closer to the Java agent's design.

## Problem

The old streaming send (`sendStreamWithTimeout`) spawned a **new goroutine per `stream.Send()`** and raced it against a 5s timer. On the *first* 5s timeout it returned `DeadlineExceeded`, cancelled the stream, and recreated it from scratch. So:

- goroutine-per-message churn on the hot span/stat paths, and
- no tolerance for transient backpressure — the first slow send tore the stream down, with no readiness/flow-control gate.

## Key finding

grpc-go exposes **no public `IsReady()`** on client streams (checked against v1.75.0). But `ClientStream.SendMsg` (what `stream.Send` calls) *blocks until HTTP/2 flow control has window space, the stream is done, or it breaks*. So in Go a blocked `Send` **is** the equivalent of the Java agent's `stream.isReady()==false` — the readiness gate is built into `Send` itself. `ClientConn.GetState`/`WaitForStateChange` only describe channel connectivity, not per-stream window space, so they aren't useful as a per-send gate.

## Changes

- **`streamSender`** — one long-lived sender goroutine per stream that owns the blocking `Send`, replacing the goroutine-per-message model. The worker submits one send and waits on it in short probe intervals.
- **`streamState`** — a port of the Java `SimpleStreamState(100, 5000)` failure window. Each probe a send stays blocked counts as one "not ready" fail; a returned send resets the window. The stream is recreated only after sustained backpressure (count + time both exceeded, ~5s), instead of on the first timeout.
- `spanStream`/`statStream` route sends through the sender; `close()` stops the sender goroutine before `CloseAndRecv` (Send and CloseAndRecv must not run concurrently).

## Preserved / unchanged

- `ping`/`command`/`close` keep `sendStreamWithTimeout` (low frequency, no churn to fix).
- Unary `SendSpanBatch` path + `concurrentRequestPermit` semaphore untouched.
- `enqueueSpan` drop-oldest policy, `newStreamWithRetry`/`waitUntilReady` reconnect, and the `skipOldSpan` heuristic all preserved.
- No config keys changed; the tuning constants are hardcoded mirrors of the Java values.

## Testing

- Added `Test_streamState_isFailure`, `Test_streamSender_toleratesTransientBlockThenSucceeds`, `Test_streamSender_givesUpAfterFailureWindow`.
- Existing span/stat tests pass unchanged (they exercise the new sender via `newSpanStream`/`newStatStream`; no mock changes needed).
- `go build ./...`, `go vet ./...`, `go test ./...`, and `go test -race` all pass.