### PR TITLE
[#121] Fix panic on malformed Pinpoint-Proxy* header values

### DIFF
--- a/plugin/http/server.go
+++ b/plugin/http/server.go
@@ -24,6 +24,7 @@ package pphttp
 
 import (
 	"bytes"
+	"math"
 	"net"
 	"net/http"
 	"reflect"
@@ -87,40 +88,57 @@ func setProxyHeader(a pinpoint.Annotation, r *http.Request) {
 	if xff := r.Header.Get("Pinpoint-ProxyApache"); xff != "" {
 		parts := strings.Split(xff, " ")
 		for _, str := range parts {
-			e := strings.Split(str, "=")
-			if e[0] == "t" {
-				receivedTime, _ = strconv.ParseInt(e[1], 10, 64)
+			k, v, ok := strings.Cut(str, "=")
+			if !ok {
+				continue
+			}
+			if k == "t" {
+				receivedTime, _ = strconv.ParseInt(v, 10, 64)
 				receivedTime = receivedTime / 1000
-			} else if e[0] == "D" {
-				durationTime, _ = strconv.Atoi(e[1])
-			} else if e[0] == "i" {
-				idlePercent, _ = strconv.Atoi(e[1])
-			} else if e[0] == "b" {
-				busyPercent, _ = strconv.Atoi(e[1])
+			} else if k == "D" {
+				durationTime, _ = strconv.Atoi(v)
+			} else if k == "i" {
+				idlePercent, _ = strconv.Atoi(v)
+			} else if k == "b" {
+				busyPercent, _ = strconv.Atoi(v)
 			}
 		}
 		code = 3
 	} else if xff := r.Header.Get("Pinpoint-ProxyNginx"); xff != "" {
 		parts := strings.Split(xff, " ")
 		for _, str := range parts {
-			e := strings.Split(str, "=")
-			if e[0] == "t" {
-				tmp, _ := strconv.ParseFloat(e[1], 64)
+			k, v, ok := strings.Cut(str, "=")
+			if !ok {
+				continue
+			}
+			if k == "t" {
+				tmp, _ := strconv.ParseFloat(v, 64)
 				tmp = tmp * 1000
-				receivedTime = int64(tmp)
-			} else if e[0] == "D" {
-				durationTime, _ = strconv.Atoi(e[1])
+				// Reject non-finite or out-of-range products before the cast:
+				// the header is untrusted input and converting such a float64
+				// to int64 yields an implementation-defined value. NaN fails
+				// both comparisons; ±Inf fails one. The upper bound uses '<'
+				// because float64(math.MaxInt64) rounds up to 2^63, which is
+				// not representable as int64.
+				if tmp >= float64(math.MinInt64) && tmp < float64(math.MaxInt64) {
+					receivedTime = int64(tmp)
+				}
+			} else if k == "D" {
+				durationTime, _ = strconv.Atoi(v)
 			}
 		}
 		code = 2
 	} else if xff := r.Header.Get("Pinpoint-ProxyApp"); xff != "" {
 		parts := strings.Split(xff, " ")
 		for _, str := range parts {
-			e := strings.Split(str, "=")
-			if e[0] == "t" {
-				receivedTime, _ = strconv.ParseInt(e[1], 10, 64)
-			} else if e[0] == "app" {
-				app = e[1]
+			k, v, ok := strings.Cut(str, "=")
+			if !ok {
+				continue
+			}
+			if k == "t" {
+				receivedTime, _ = strconv.ParseInt(v, 10, 64)
+			} else if k == "app" {
+				app = v
 			}
 		}
 		code = 1

--- a/plugin/http/server_test.go
+++ b/plugin/http/server_test.go
@@ -1,0 +1,111 @@
+package pphttp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pinpoint-apm/pinpoint-go-agent"
+)
+
+type proxyValues struct {
+	called       bool
+	key          int32
+	receivedTime int64
+	code         int32
+	duration     int32
+	idle         int32
+	busy         int32
+	app          string
+}
+
+// proxyAnnotation captures the single proxy header annotation setProxyHeader records.
+type proxyAnnotation struct {
+	got proxyValues
+}
+
+func (a *proxyAnnotation) AppendLongIntIntByteByteString(key int32, l int64, i1 int32, i2 int32, b1 int32, b2 int32, s string) {
+	a.got = proxyValues{true, key, l, i1, i2, b1, b2, s}
+}
+
+func (a *proxyAnnotation) AppendInt(int32, int32)                                {}
+func (a *proxyAnnotation) AppendLong(int32, int64)                               {}
+func (a *proxyAnnotation) AppendString(int32, string)                            {}
+func (a *proxyAnnotation) AppendStringString(int32, string, string)              {}
+func (a *proxyAnnotation) AppendIntStringString(int32, int32, string, string)    {}
+func (a *proxyAnnotation) AppendBytesStringString(int32, []byte, string, string) {}
+
+func Test_setProxyHeader(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		value  string
+		want   proxyValues
+	}{
+		{name: "no proxy header"},
+
+		{name: "apache", header: "Pinpoint-ProxyApache", value: "t=1500968753503 D=125 i=51 b=48",
+			want: proxyValues{called: true, code: 3, receivedTime: 1500968753, duration: 125, idle: 51, busy: 48}},
+		{name: "apache bare token", header: "Pinpoint-ProxyApache", value: "t",
+			want: proxyValues{called: true, code: 3}},
+		{name: "apache bare token before valid ones", header: "Pinpoint-ProxyApache", value: "t D=125 junk i=51 b",
+			want: proxyValues{called: true, code: 3, duration: 125, idle: 51}},
+		{name: "apache empty values", header: "Pinpoint-ProxyApache", value: "t= D= i= b=",
+			want: proxyValues{called: true, code: 3}},
+		{name: "apache extra spaces", header: "Pinpoint-ProxyApache", value: "  t=1500968753503   D=125  ",
+			want: proxyValues{called: true, code: 3, receivedTime: 1500968753, duration: 125}},
+
+		{name: "nginx", header: "Pinpoint-ProxyNginx", value: "t=1504164327.484 D=0.000",
+			want: proxyValues{called: true, code: 2, receivedTime: 1504164327484}},
+		{name: "nginx bare token", header: "Pinpoint-ProxyNginx", value: "t",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx bare token before valid one", header: "Pinpoint-ProxyNginx", value: "t D=7",
+			want: proxyValues{called: true, code: 2, duration: 7}},
+		{name: "nginx empty values", header: "Pinpoint-ProxyNginx", value: "t= D=",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx NaN", header: "Pinpoint-ProxyNginx", value: "t=NaN",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx +Inf", header: "Pinpoint-ProxyNginx", value: "t=Inf",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx -Inf", header: "Pinpoint-ProxyNginx", value: "t=-Inf",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx overflow", header: "Pinpoint-ProxyNginx", value: "t=1e400",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx negative overflow", header: "Pinpoint-ProxyNginx", value: "t=-1e400",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx out of int64 range", header: "Pinpoint-ProxyNginx", value: "t=1e300",
+			want: proxyValues{called: true, code: 2}},
+		{name: "nginx unparsable", header: "Pinpoint-ProxyNginx", value: "t=abc",
+			want: proxyValues{called: true, code: 2}},
+
+		{name: "app", header: "Pinpoint-ProxyApp", value: "t=1500968753503 app=foo-bar",
+			want: proxyValues{called: true, code: 1, receivedTime: 1500968753503, app: "foo-bar"}},
+		{name: "app bare token", header: "Pinpoint-ProxyApp", value: "app",
+			want: proxyValues{called: true, code: 1}},
+		{name: "app bare token before valid one", header: "Pinpoint-ProxyApp", value: "app t=1500968753503",
+			want: proxyValues{called: true, code: 1, receivedTime: 1500968753503}},
+		{name: "app empty values", header: "Pinpoint-ProxyApp", value: "t= app=",
+			want: proxyValues{called: true, code: 1}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			if tt.header != "" {
+				req.Header.Set(tt.header, tt.value)
+			}
+
+			want := tt.want
+			if want.called {
+				want.key = pinpoint.AnnotationHttpProxyHeader
+			}
+
+			a := &proxyAnnotation{}
+			setProxyHeader(a, req)
+
+			if a.got != want {
+				t.Errorf("%s: %q\n got: %+v\nwant: %+v", tt.header, tt.value, a.got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #121

## Problem

`setProxyHeader` split each space-delimited token of the `Pinpoint-Proxy*` headers on `=` and read `e[1]` without a length check:

```go
e := strings.Split(str, "=")
if e[0] == "t" {
    receivedTime, _ = strconv.ParseInt(e[1], 10, 64)   // out of range when str has no "="
```

A token that is a recognized key with no `=` — `Pinpoint-ProxyApache: t` — panics with `index out of range [1] with length 1` inside the HTTP handler, aborting the response. The header is client-supplied, so any request can trigger it, and all three branches (Apache, Nginx, App) had the same bug.

The Nginx branch additionally cast the parsed float to `int64` unguarded. `strconv.ParseFloat` accepts `NaN` and `Inf`, and returns `±Inf` with `ErrRange` for input like `1e400` — and that error was discarded. Converting a non-finite or out-of-range `float64` to `int64` is implementation-defined in Go, so `t=NaN` or `t=1e400` recorded a garbage `receivedTime`.

## Change

- Parse each token with `strings.Cut` and skip tokens carrying no `=`, in all three branches.
- Range-check the Nginx value before the `int64` conversion:

```go
if tmp >= float64(math.MinInt64) && tmp < float64(math.MaxInt64) {
    receivedTime = int64(tmp)
}
```

The upper bound uses `<` because `float64(math.MaxInt64)` rounds up to 2^63, which is not representable as `int64`. `NaN` fails both comparisons and `±Inf` fails one. This matches how the C++ agent guards the same conversion (`src/http.cpp`).

Behavior for well-formed headers is unchanged, and malformed tokens are now skipped instead of aborting the request.

## Tests

`Test_setProxyHeader` in `plugin/http/server_test.go` — 21 cases across all three headers, covering bare tokens, a bare token followed by valid ones (so a skipped token does not abort the loop), empty values, `NaN`, `±Inf`, `±1e400`, `1e300`, repeated spaces, and normal values.

Verified the test reproduces the original bug: against the pre-fix `setProxyHeader` it fails with `panic: index out of range [1] with length 1`, and passes after the change.

```
cd plugin/http && go test .
ok  	github.com/pinpoint-apm/pinpoint-go-agent/plugin/http
```

Note that `go test ./plugin/http/...` does not work from the repository root, since `plugin/http` is a separate module.
