### PR TITLE
[#123] Make agent enable/shutdown flags atomic

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -53,8 +53,8 @@ type agent struct {
 	config    *Config
 	connectWg sync.WaitGroup
 	workerWg  sync.WaitGroup
-	enable    bool
-	shutdown  bool
+	enable    atomic.Bool
+	shutdown  atomic.Bool
 
 	// grpcMetaCtx caches the outgoing-metadata context (socketId <= 0), whose
 	// headers are immutable for the agent's lifetime, so per-send callers reuse
@@ -239,7 +239,7 @@ func (agent *agent) connectGrpcServer() {
 		return
 	}
 
-	agent.enable = true
+	agent.enable.Store(true)
 	go agent.sendPingWorker()
 	if agent.config.Bool(CfgSpanBatchEnable) {
 		go agent.sendSpanBatchWorker()
@@ -259,16 +259,19 @@ func (agent *agent) Shutdown() {
 	// get delay in case shutdown was called too early
 	time.Sleep(1 * time.Second)
 
-	agent.shutdown = true
+	agent.shutdown.Store(true)
 	Log("agent").Infof("shutdown pinpoint agent")
 
 	// wait for the grpc connection to be completed
 	agent.connectWg.Wait()
-	if !agent.enable {
+	// CompareAndSwap, not Load-then-Store: two concurrent Shutdown calls could
+	// both pass a plain check and both reach the close() calls below, panicking
+	// on the second close of an already-closed channel. Only the swap winner
+	// proceeds.
+	if !agent.enable.CompareAndSwap(true, false) {
 		return
 	}
 
-	agent.enable = false
 	globalAgent = NoopAgent()
 
 	close(agent.spanChan)
@@ -306,7 +309,7 @@ func (agent *agent) Shutdown() {
 func (agent *agent) NewSpanTracer(operation string, rpcName string) Tracer {
 	var tracer Tracer
 
-	if agent.enable {
+	if agent.enable.Load() {
 		reader := &noopDistributedTracingContextReader{}
 		tracer = agent.NewSpanTracerWithReader(operation, rpcName, reader)
 	} else {
@@ -316,7 +319,7 @@ func (agent *agent) NewSpanTracer(operation string, rpcName string) Tracer {
 }
 
 func (agent *agent) NewSpanTracerWithReader(operation string, rpcName string, reader DistributedTracingContextReader) Tracer {
-	if !agent.enable || reader == nil {
+	if !agent.enable.Load() || reader == nil {
 		return NoopTracer()
 	}
 
@@ -353,7 +356,7 @@ func (agent *agent) generateTransactionId() TransactionId {
 }
 
 func (agent *agent) Enable() bool {
-	return agent.enable
+	return agent.enable.Load()
 }
 
 func (agent *agent) Config() *Config {
@@ -368,7 +371,7 @@ func (agent *agent) sendPingWorker() {
 	agent.pingDone = make(chan bool)
 	stream := agent.agentGrpc.newPingStreamWithRetry()
 
-	for agent.enable {
+	for agent.enable.Load() {
 		err := stream.sendPing()
 		if err != nil {
 			if err != io.EOF {
@@ -403,7 +406,7 @@ func (agent *agent) sendSpanWorker() {
 
 	stream := agent.spanGrpc.newSpanStreamWithRetry()
 	for chunk := range agent.spanChan {
-		if !agent.enable {
+		if !agent.enable.Load() {
 			break
 		}
 
@@ -460,7 +463,7 @@ func (agent *agent) sendSpanBatchWorker() {
 }
 
 func (agent *agent) enqueueSpan(span *spanChunk) bool {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return false
 	}
 
@@ -495,7 +498,7 @@ func (agent *agent) sendMetaWorker() {
 	defer agent.workerWg.Done()
 
 	for md := range agent.metaChan {
-		if !agent.enable {
+		if !agent.enable.Load() {
 			break
 		}
 
@@ -551,7 +554,7 @@ func (agent *agent) deleteMetaCache(md interface{}) {
 }
 
 func (agent *agent) tryEnqueueMeta(md interface{}) bool {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return false
 	}
 
@@ -570,7 +573,7 @@ func (agent *agent) tryEnqueueMeta(md interface{}) bool {
 }
 
 func (agent *agent) cacheError(errorName string) int32 {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return 0
 	}
 
@@ -601,7 +604,7 @@ func abbreviateString(str string, length int) string {
 }
 
 func (agent *agent) cacheSql(sql string) int32 {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return 0
 	}
 
@@ -626,7 +629,7 @@ func (agent *agent) cacheSql(sql string) int32 {
 }
 
 func (agent *agent) cacheSqlUid(sql string) []byte {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return nil
 	}
 
@@ -653,7 +656,7 @@ func (agent *agent) cacheSqlUid(sql string) []byte {
 }
 
 func (agent *agent) cacheSpanApi(descriptor string, apiType int) int32 {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return 0
 	}
 
@@ -680,7 +683,7 @@ func (agent *agent) cacheSpanApi(descriptor string, apiType int) int32 {
 }
 
 func (agent *agent) enqueueExceptionMeta(span *span) {
-	if !agent.enable || !agent.config.errorTraceCallStack {
+	if !agent.enable.Load() || !agent.config.errorTraceCallStack {
 		return
 	}
 
@@ -702,7 +705,7 @@ func (agent *agent) enqueueExceptionMeta(span *span) {
 }
 
 func (agent *agent) enqueueUrlStat(stat *urlStat) bool {
-	if !agent.enable {
+	if !agent.enable.Load() {
 		return false
 	}
 
@@ -730,7 +733,7 @@ func (agent *agent) collectUrlStatWorker() {
 	agent.initUrlStat()
 
 	for uri := range agent.urlStatChan {
-		if !agent.enable {
+		if !agent.enable.Load() {
 			break
 		}
 		agent.addUrlStatSnapshot(uri)
@@ -746,7 +749,7 @@ func (agent *agent) sendUrlStatWorker() {
 	agent.urlStatTicker = time.NewTicker(30 * time.Second)
 	agent.urlStatDone = make(chan bool)
 
-	for agent.enable {
+	for agent.enable.Load() {
 		select {
 		case <-agent.urlStatDone:
 			Log("agent").Infof("end send uri stat goroutine")
@@ -781,7 +784,7 @@ func (agent *agent) sendStatsWorker() {
 
 	stream := agent.statGrpc.newStatStreamWithRetry()
 	for stats := range agent.statChan {
-		if !agent.enable {
+		if !agent.enable.Load() {
 			break
 		}
 
@@ -842,7 +845,7 @@ func NewTestAgent(config *Config, t *testing.T) (Agent, error) {
 	//agent.statGrpc = newMockStatGrpc(agent, t)
 
 	globalAgent = agent
-	agent.enable = true
+	agent.enable.Store(true)
 
 	return agent, nil
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -54,7 +54,7 @@ func Test_agent_NewAgent(t *testing.T) {
 			assert.Equal(t, globalAgent, a, "global agent")
 
 			agent.startTime = 12345
-			agent.enable = true
+			agent.enable.Store(true)
 			assert.Equal(t, "testagent^12345^1", agent.generateTransactionId().String(), "generateTransactionId")
 
 			a.Shutdown()
@@ -80,7 +80,7 @@ func Test_agent_GlobalAgent(t *testing.T) {
 	c.offGrpc = true
 	a, _ := NewAgent(c)
 	agent := a.(*agent)
-	agent.enable = true
+	agent.enable.Store(true)
 	defer a.Shutdown()
 
 	tests := []struct {
@@ -114,7 +114,7 @@ func Test_agent_NewSpanTracer(t *testing.T) {
 	c.offGrpc = true
 	a, _ := NewAgent(c)
 	agent := a.(*agent)
-	agent.enable = true
+	agent.enable.Store(true)
 	defer a.Shutdown()
 
 	tests := []struct {
@@ -153,7 +153,7 @@ func Test_agent_NewSpanTracerWithReader(t *testing.T) {
 	c.offGrpc = true
 	a, _ := NewAgent(c)
 	agent := a.(*agent)
-	agent.enable = true
+	agent.enable.Store(true)
 	defer a.Shutdown()
 
 	m := map[string]string{

--- a/command.go
+++ b/command.go
@@ -25,7 +25,7 @@ func (agent *agent) runCommandService() {
 	defer agent.workerWg.Done()
 	gAtcStreamCount = 0
 
-	for agent.enable {
+	for agent.enable.Load() {
 		stream := agent.cmdGrpc.newCommandStreamWithRetry()
 		err := stream.sendCommandMessage()
 		if err != nil {
@@ -36,10 +36,10 @@ func (agent *agent) runCommandService() {
 			continue
 		}
 
-		for agent.enable {
+		for agent.enable.Load() {
 			cmdReq, err := stream.recvCommandRequest()
 			if err != nil {
-				if agent.enable && err != io.EOF {
+				if agent.enable.Load() && err != io.EOF {
 					Log("cmd").Warnf("recv command request - %v", err)
 				}
 				break
@@ -86,7 +86,7 @@ func (agent *agent) sendActiveThreadCount(s *activeThreadCountStream) {
 	atomic.AddInt32(&gAtcStreamCount, 1)
 	Log("cmd").Infof("active thread count stream goroutine start: %d, %d", s.reqId, gAtcStreamCount)
 
-	for agent.enable {
+	for agent.enable.Load() {
 		err := s.sendActiveThreadCount()
 		if err != nil {
 			if err != io.EOF {

--- a/grpc.go
+++ b/grpc.go
@@ -292,7 +292,7 @@ func (agentGrpc *agentGrpc) sendAgentInfo(ctx context.Context, agentInfo *pb.PAg
 func (agentGrpc *agentGrpc) registerAgentWithRetry() bool {
 	ctx, agentInfo := agentGrpc.makeAgentInfo()
 
-	for !agentGrpc.agent.shutdown {
+	for !agentGrpc.agent.shutdown.Load() {
 		if res, err := agentGrpc.sendAgentInfo(ctx, agentInfo); err == nil {
 			if res.Success {
 				Log("agent").Infof("success to register agent")
@@ -303,7 +303,7 @@ func (agentGrpc *agentGrpc) registerAgentWithRetry() bool {
 			}
 		}
 
-		for retry := 1; !agentGrpc.agent.shutdown; retry++ {
+		for retry := 1; !agentGrpc.agent.shutdown.Load(); retry++ {
 			if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
 				break
 			}

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -20,7 +20,6 @@ func newTestAgent(config *Config) *agent {
 		agentID:   "testAgent",
 		appType:   ServiceTypeGoApp,
 		startTime: time.Now().UnixNano() / int64(time.Millisecond),
-		enable:    true,
 		spanChan:  make(chan *spanChunk, cacheSize),
 		metaChan:  make(chan interface{}, cacheSize),
 		sampler:   newBasicTraceSampler(newRateSampler(1)),
@@ -32,6 +31,7 @@ func newTestAgent(config *Config) *agent {
 			applicationName: "testApp",
 		},
 	}
+	a.enable.Store(true)
 	a.errorCache, _ = lru.New(cacheSize)
 	a.sqlCache, _ = lru.New(cacheSize)
 	a.sqlUidCache, _ = lru.New(cacheSize)

--- a/stats.go
+++ b/stats.go
@@ -254,7 +254,7 @@ func (agent *agent) collectAgentStatWorker() {
 	collected := make([]*inspectorStats, cfgBatchCount)
 	batch := 0
 
-	for agent.enable {
+	for agent.enable.Load() {
 		select {
 		case <-agent.statDone:
 			Log("stats").Infof("end collect agent stat goroutine")


### PR DESCRIPTION
## Summary

`agent.enable` and `agent.shutdown` were plain `bool` fields. `Shutdown()` wrote
both from the calling goroutine while every worker loop and the exported
`Enable()` read them concurrently, with no synchronization — a data race, and a
shutdown that workers may not observe for an unbounded time.

Resolves #123.

## Changes

- `enable` and `shutdown` are now `sync/atomic.Bool`; all 33 access sites across
  `agent.go`, `command.go`, `grpc.go`, `stats.go`, `mock_grpc.go` and
  `agent_test.go` go through `Load` / `Store`.
- `Shutdown()`'s check-then-clear is now a `CompareAndSwap`. As two separate
  atomic operations it would remain a check-then-act: two concurrent
  `Shutdown()` calls could both pass the check and both reach the `close()`
  calls, panicking on the second close of the same channel.

## Verification

- `go build ./...`, `go vet ./...` and `go test -race ./...` all pass.
- The reproduction from #123 (concurrent `Enable()` / `Shutdown()`) reports
  `WARNING: DATA RACE` on `main` and passes with this change.

## Note

This does not by itself close #111. Making the flag atomic removes the
visibility hole behind that panic, but `enqueueStat` still has no `enable`
guard of its own, unlike its siblings `enqueueSpan`, `tryEnqueueMeta` and
`enqueueUrlStat`. That is worth deciding separately.
