### PR TITLE
[#122] Replace ExcludeUrl regexp conversion with an Ant matcher

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -501,6 +501,11 @@ http:
 ### Http.Server.ExcludeUrl
 Http.Server.ExcludeUrl option sets URLs to exclude from tracking.
 It supports ant style pattern. (e.g. /aa/*.html, /??/exclude.html)
+A pattern matches the whole URL path, where `?` matches exactly one character other than `/`,
+`*` matches zero or more characters within a single path segment, and `**` matches zero or more
+characters across path segments. Every other character, including regular expression
+metacharacters, is matched literally. URI template variables (e.g. `/aa/{name}.html`) are not
+supported.
 Refer https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/AntPathMatcher.html.
 
 * --pinpoint-http-server-excludeurl

--- a/plugin/http/url.go
+++ b/plugin/http/url.go
@@ -1,73 +1,171 @@
 package pphttp
 
 import (
-	"bytes"
-	"regexp"
 	"strings"
 
 	"github.com/pinpoint-apm/pinpoint-go-agent"
 )
 
+// Ant style pattern kinds. Patterns are classified once at configuration time so
+// that the common shapes never pay for the general matcher on the request path.
+type patternKind int
+
+const (
+	patternExact         patternKind = iota // no wildcard: plain string equality
+	patternPrefix                           // "prefix**": prefix test
+	patternSegmentPrefix                    // "prefix*": prefix test, no '/' beyond the prefix
+	patternAnt                              // everything else: token matcher
+)
+
+type tokenKind int
+
+const (
+	tokenLiteral         tokenKind = iota
+	tokenStar                      // '*'  - zero or more characters within one path segment
+	tokenDoubleStar                // '**' - zero or more characters across path segments
+	tokenDoubleStarSlash           // '**/' - like '**', but only while URL input remains
+	tokenQuestion                  // '?'  - exactly one character, never the path separator
+)
+
+type patternToken struct {
+	kind  tokenKind
+	value byte
+}
+
 type httpExcludeUrl struct {
-	pattern *regexp.Regexp
+	kind          patternKind
+	pattern       string
+	literalPrefix string
+	minLength     int
+	tokens        []patternToken
 }
 
 func (h *httpExcludeUrl) match(urlPath string) bool {
-	if h.pattern != nil {
-		return h.pattern.MatchString(urlPath)
+	switch h.kind {
+	case patternExact:
+		return urlPath == h.pattern
+	case patternPrefix:
+		return strings.HasPrefix(urlPath, h.literalPrefix)
+	case patternSegmentPrefix:
+		return strings.HasPrefix(urlPath, h.literalPrefix) &&
+			!strings.Contains(urlPath[len(h.literalPrefix):], "/")
+	default:
+		return h.antMatch(urlPath)
 	}
-
-	return false
 }
 
-func newHttpExcludeUrl(urlPath string) *httpExcludeUrl {
-	h := httpExcludeUrl{pattern: nil}
-
-	pinpoint.Log("http").Debugf("newHttpExcludeUrl: %s, %s", urlPath, convertToRegexp(urlPath))
-
-	r, err := regexp.Compile(convertToRegexp(urlPath))
-	if err == nil {
-		h.pattern = r
-	}
-	return &h
+func containsWildcard(s string) bool {
+	return strings.ContainsAny(s, "*?")
 }
 
-func convertToRegexp(antPath string) string {
-	var buf bytes.Buffer
-	buf.WriteRune('^')
+func newHttpExcludeUrl(antPath string) *httpExcludeUrl {
+	h := &httpExcludeUrl{pattern: antPath}
 
-	afterStar := false
-	for _, c := range antPath {
-		if afterStar {
-			if c == '*' {
-				buf.WriteString(".*")
-			} else {
-				buf.WriteString("[^/]*")
-				writeRune(&buf, c)
-			}
-			afterStar = false
-		} else {
-			if c == '*' {
-				afterStar = true
-			} else {
-				writeRune(&buf, c)
-			}
+	if !containsWildcard(antPath) {
+		h.kind = patternExact
+		return h
+	}
+
+	if strings.HasSuffix(antPath, "**") {
+		if prefix := antPath[:len(antPath)-2]; !containsWildcard(prefix) {
+			h.kind = patternPrefix
+			h.literalPrefix = prefix
+			return h
 		}
 	}
 
-	if afterStar {
-		buf.WriteString("[^/]*")
+	if strings.HasSuffix(antPath, "*") && !strings.HasSuffix(antPath, "**") {
+		if prefix := antPath[:len(antPath)-1]; !containsWildcard(prefix) {
+			h.kind = patternSegmentPrefix
+			h.literalPrefix = prefix
+			return h
+		}
 	}
 
-	buf.WriteRune('$')
-	return buf.String()
+	h.kind = patternAnt
+	if i := strings.IndexAny(antPath, "*?"); i > 0 {
+		h.literalPrefix = antPath[:i]
+	}
+
+	for i := 0; i < len(antPath); {
+		c := antPath[i]
+		switch {
+		case c == '*' && i+1 < len(antPath) && antPath[i+1] == '*':
+			if i+2 < len(antPath) && antPath[i+2] == '/' {
+				h.tokens = append(h.tokens, patternToken{kind: tokenDoubleStarSlash})
+				i += 3
+			} else {
+				h.tokens = append(h.tokens, patternToken{kind: tokenDoubleStar})
+				i += 2
+			}
+		case c == '*':
+			h.tokens = append(h.tokens, patternToken{kind: tokenStar})
+			i++
+		case c == '?':
+			h.tokens = append(h.tokens, patternToken{kind: tokenQuestion})
+			h.minLength++
+			i++
+		default:
+			h.tokens = append(h.tokens, patternToken{kind: tokenLiteral, value: c})
+			h.minLength++
+			i++
+		}
+	}
+
+	return h
 }
 
-func writeRune(buf *bytes.Buffer, c rune) {
-	if c == '.' || c == '+' || c == '^' || c == '[' || c == ']' || c == '{' || c == '}' {
-		buf.WriteRune('\\')
+// antScratchLen sizes the stack resident DP rows. Longer URLs fall back to the heap.
+const antScratchLen = 256
+
+// antMatch runs a two row suffix DP over the compiled tokens: next[i] holds
+// "the token suffix not yet processed matches urlPath[i:]".
+func (h *httpExcludeUrl) antMatch(urlPath string) bool {
+	u := len(urlPath)
+	if u < h.minLength || !strings.HasPrefix(urlPath, h.literalPrefix) {
+		return false
 	}
-	buf.WriteRune(c)
+
+	var scratch [2 * antScratchLen]bool
+	var cur, next []bool
+	if n := u + 1; n <= antScratchLen {
+		cur, next = scratch[:n], scratch[antScratchLen:antScratchLen+n]
+	} else {
+		cur, next = make([]bool, n), make([]bool, n)
+	}
+	next[u] = true
+
+	for i := len(h.tokens) - 1; i >= 0; i-- {
+		t := h.tokens[i]
+		switch t.kind {
+		case tokenLiteral:
+			cur[u] = false
+			for j := u - 1; j >= 0; j-- {
+				cur[j] = urlPath[j] == t.value && next[j+1]
+			}
+		case tokenQuestion:
+			cur[u] = false
+			for j := u - 1; j >= 0; j-- {
+				cur[j] = urlPath[j] != '/' && next[j+1]
+			}
+		case tokenStar:
+			cur[u] = next[u]
+			for j := u - 1; j >= 0; j-- {
+				cur[j] = next[j] || (urlPath[j] != '/' && cur[j+1])
+			}
+		case tokenDoubleStar, tokenDoubleStarSlash:
+			// '**/' may skip the separator, but only while URL input remains.
+			cur[u] = t.kind == tokenDoubleStar && next[u]
+			running := next[u]
+			for j := u - 1; j >= 0; j-- {
+				running = running || next[j]
+				cur[j] = running
+			}
+		}
+		cur, next = next, cur
+	}
+
+	return next[0]
 }
 
 type httpUrlFilter struct {
@@ -87,7 +185,13 @@ func setupHttpUrlFilter() []*httpExcludeUrl {
 	trimStringSlice(cfgFilters)
 
 	for _, u := range cfgFilters {
-		filters = append(filters, newHttpExcludeUrl(u))
+		if u == "" {
+			pinpoint.Log("http").Warnf("%s: empty pattern is ignored", CfgHttpServerExcludeUrl)
+			continue
+		}
+		h := newHttpExcludeUrl(u)
+		pinpoint.Log("http").Debugf("%s: %s (kind: %d)", CfgHttpServerExcludeUrl, h.pattern, h.kind)
+		filters = append(filters, h)
 	}
 
 	return filters

--- a/plugin/http/url_test.go
+++ b/plugin/http/url_test.go
@@ -1,0 +1,193 @@
+package pphttp
+
+import "testing"
+
+func TestHttpExcludeUrlMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		kind    patternKind
+		match   []string
+		noMatch []string
+	}{
+		{
+			name:    "no wildcard is an exact match",
+			pattern: "/exclude.html",
+			kind:    patternExact,
+			match:   []string{"/exclude.html"},
+			noMatch: []string{"/exclude.htm", "/exclude.htmlx", "/a/exclude.html", ""},
+		},
+		{
+			name:    "doc example: ? matches exactly one character",
+			pattern: "/??/exclude.html",
+			kind:    patternAnt,
+			match:   []string{"/ab/exclude.html", "/12/exclude.html", "/../exclude.html"},
+			noMatch: []string{
+				"/a/exclude.html",   // too few
+				"/abc/exclude.html", // too many
+				"/exclude.html",     // the old regexp made '??' a lazy optional on '/'
+				"//exclude.html",
+			},
+		},
+		{
+			name:    "? never matches the path separator",
+			pattern: "/a?c",
+			kind:    patternAnt,
+			match:   []string{"/abc", "/a.c"},
+			noMatch: []string{"/a/c", "/ac", "/abbc"},
+		},
+		{
+			name:    "doc example: * stays inside one segment",
+			pattern: "/aa/*.html",
+			kind:    patternAnt,
+			match:   []string{"/aa/.html", "/aa/index.html", "/aa/a.b.html"},
+			noMatch: []string{"/aa/bb/index.html", "/aa/index.htm", "/bb/index.html"},
+		},
+		{
+			name:    "trailing * is a segment prefix",
+			pattern: "/aa/*",
+			kind:    patternSegmentPrefix,
+			match:   []string{"/aa/", "/aa/index.html"},
+			noMatch: []string{"/aa", "/aa/bb/index.html", "/bb/"},
+		},
+		{
+			name:    "trailing ** is a plain prefix",
+			pattern: "/aa/**",
+			kind:    patternPrefix,
+			match:   []string{"/aa/", "/aa/index.html", "/aa/bb/cc/index.html"},
+			noMatch: []string{"/aa", "/bb/index.html"},
+		},
+		{
+			name:    "** alone matches everything",
+			pattern: "**",
+			kind:    patternPrefix,
+			match:   []string{"", "/", "/a/b/c"},
+		},
+		{
+			name:    "* alone matches a single segment",
+			pattern: "*",
+			kind:    patternSegmentPrefix,
+			match:   []string{"", "a", "abc"},
+			noMatch: []string{"/", "/a", "a/b"},
+		},
+		{
+			name:    "** in the middle spans segments",
+			pattern: "/aa/**/index.html",
+			kind:    patternAnt,
+			match: []string{
+				"/aa/index.html", // '**/' collapses to nothing
+				"/aa/bb/index.html",
+				"/aa/bb/cc/index.html",
+			},
+			noMatch: []string{"/aa/index.htm", "/bb/index.html", "/aaindex.html"},
+		},
+		{
+			name:    "leading ** spans segments",
+			pattern: "**/exclude.html",
+			kind:    patternAnt,
+			match:   []string{"/exclude.html", "/a/b/exclude.html", "exclude.html"},
+			noMatch: []string{"/exclude.html/x", "/excludexhtml"},
+		},
+		{
+			name:    "mixed wildcards",
+			pattern: "/api/v?/**/*.json",
+			kind:    patternAnt,
+			match:   []string{"/api/v1/a.json", "/api/v2/x/y/z.json"},
+			noMatch: []string{"/api/v/a.json", "/api/v10/a.json", "/api/v1/a.xml"},
+		},
+		{
+			// The regexp converter escaped only . + ^ [ ] { } — these leaked through.
+			name:    "regexp metacharacters are literal",
+			pattern: "/a(b)|c$d\\e.f+g",
+			kind:    patternExact,
+			match:   []string{"/a(b)|c$d\\e.f+g"},
+			noMatch: []string{"/ab", "/c$d", "/aXbc$dXeXfg", "/a(b)|c$d\\e.fg"},
+		},
+		{
+			// Compiling this as a regexp fails; the filter used to vanish silently.
+			name:    "unbalanced regexp metacharacters still filter",
+			pattern: "/foo(*",
+			kind:    patternSegmentPrefix,
+			match:   []string{"/foo(", "/foo(bar"},
+			noMatch: []string{"/foo", "/foobar", "/foo(bar/baz"},
+		},
+		{
+			name:    "bracket metacharacters are literal, not a character class",
+			pattern: "/[ab]/*.html",
+			kind:    patternAnt,
+			match:   []string{"/[ab]/x.html"},
+			noMatch: []string{"/a/x.html", "/b/x.html"},
+		},
+		{
+			name:    "quantifier metacharacters are literal",
+			pattern: "/a{2}?/x",
+			kind:    patternAnt,
+			match:   []string{"/a{2}b/x"},
+			noMatch: []string{"/aa/x", "/a{2}/x"},
+		},
+		{
+			// Degenerate input: '***' tokenizes as '**' + '*', so the following
+			// '/' stays a literal and is not collapsed the way '**/' is.
+			name:    "consecutive stars beyond two",
+			pattern: "/a/***/b",
+			kind:    patternAnt,
+			match:   []string{"/a/x/b", "/a/x/y/b"},
+			noMatch: []string{"/a/b", "/a/b/c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newHttpExcludeUrl(tt.pattern)
+			if h.kind != tt.kind {
+				t.Errorf("newHttpExcludeUrl(%q).kind = %d, want %d", tt.pattern, h.kind, tt.kind)
+			}
+			for _, url := range tt.match {
+				if !h.match(url) {
+					t.Errorf("pattern %q should match %q", tt.pattern, url)
+				}
+			}
+			for _, url := range tt.noMatch {
+				if h.match(url) {
+					t.Errorf("pattern %q should not match %q", tt.pattern, url)
+				}
+			}
+		})
+	}
+}
+
+// The stack resident DP rows only cover urls up to antScratchLen; longer ones
+// take the heap fallback and must still match.
+func TestHttpExcludeUrlLongUrl(t *testing.T) {
+	h := newHttpExcludeUrl("/a?c/**/x.html")
+
+	long := "/abc"
+	for len(long) < 2*antScratchLen {
+		long += "/segment"
+	}
+
+	if !h.match(long + "/x.html") {
+		t.Errorf("pattern should match long url of %d bytes", len(long)+7)
+	}
+	if h.match(long + "/x.htm") {
+		t.Errorf("pattern should not match long url with a different suffix")
+	}
+}
+
+func TestHttpUrlFilterIsFiltered(t *testing.T) {
+	f := &httpUrlFilter{filters: []*httpExcludeUrl{
+		newHttpExcludeUrl("/??/exclude.html"),
+		newHttpExcludeUrl("/static/**"),
+	}}
+
+	for _, url := range []string{"/ab/exclude.html", "/static/js/app.js"} {
+		if !f.isFiltered(url) {
+			t.Errorf("isFiltered(%q) = false, want true", url)
+		}
+	}
+	for _, url := range []string{"/exclude.html", "/statics/js/app.js"} {
+		if f.isFiltered(url) {
+			t.Errorf("isFiltered(%q) = true, want false", url)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #122

## Problem

`doc/config.md` documents `Http.Server.ExcludeUrl` as supporting Ant style patterns and gives `/??/exclude.html` as an example, but `convertToRegexp` only translated `*` and `**`. `?` was passed through untouched and the escape list in `writeRune` covered only `. + ^ [ ] { }`, so `?` and the metacharacters `( ) | $ \` kept their regular expression meaning:

```go
r, err := regexp.Compile(convertToRegexp(urlPath))
if err == nil {
    h.pattern = r
}
return &h   // err != nil -> pattern stays nil, no log, no error
```

The documented example became `^/??/exclude\.html$`, where `??` is a lazy optional quantifier on the preceding `/` rather than a single character wildcard. It compiled cleanly, so nothing reported a problem:

| Configured pattern | Generated regexp | URL | Expected | Before |
|---|---|---|---|---|
| `/??/exclude.html` | `^/??/exclude\.html$` | `/ab/exclude.html` | excluded | **tracked** |
| `/??/exclude.html` | | `/exclude.html` | tracked | **excluded** |
| `/a(b)/x.html` | `^/a(b)/x\.html$` | `/ab/x.html` | tracked | **excluded** |
| `/foo\|bar` | `^/foo\|bar$` | `/unrelated/sidebar` | tracked | **excluded** |
| `/a$b` | `^/a$b$` | `/a$b` | excluded | **matches nothing** |
| `/foo(` | `^/foo($` | *(any)* | excluded | **filter silently dropped** |

The last row is the worst case: `regexp.Compile` fails, `h.pattern` stays `nil`, `match` returns `false` for everything, and every URL the operator meant to exclude is tracked with nothing in the logs to explain it.

## Change

Drop the regexp conversion and match Ant patterns directly, following the C++ agent (`src/http.h`, `src/http.cpp`).

Each pattern is classified once at configuration time:

| Kind | Shape | Per-request cost |
|---|---|---|
| `Exact` | no wildcard | string compare |
| `Prefix` | `p**` | `HasPrefix` |
| `SegmentPrefix` | `p*` | `HasPrefix` + no `/` past the prefix |
| `Ant` | everything else | token matcher |

`Ant` patterns compile to a token stream (`Literal` / `Star` / `DoubleStar` / `DoubleStarSlash` / `Question`) matched by a two row suffix DP, guarded by `minLength` and literal-prefix fast rejects. `?` is a real token, and no input character is ever reinterpreted as a metacharacter. The DP rows are stack resident for URLs up to 256 bytes and fall back to the heap beyond that.

No compile step is left that can fail, so the `nil` pattern path that silently disabled a filter is gone. Blank patterns are logged and skipped instead.

`doc/config.md` now states the wildcards that are actually implemented — the Spring `AntPathMatcher` link on its own implied URI template variables (`/aa/{name}.html`) that the agent does not support.

### Behavior changes beyond the `?` fix

- Regular expression metacharacters (`( ) | $ \ . + [ ] { }`) are now matched literally.
- `**/` collapses the separator, so `/aa/**/index.html` now matches `/aa/index.html`. Spring's `AntPathMatcher` does the same; the old `^/aa/.*/index\.html$` did not.

### Tests

`plugin/http/url_test.go` adds a table test covering `?`, `*`, `**`, `**/`, each pattern kind, the regexp metacharacters listed above, the previously uncompilable `/foo(`, and the documented `/??/exclude.html` example. Also covers the heap fallback for URLs longer than the stack rows.

```
go test -C plugin/http -race -count=1 .
ok  	github.com/pinpoint-apm/pinpoint-go-agent/plugin/http
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
