### PR TITLE
[#124] Inject trace context on event overflow

### DIFF
--- a/span.go
+++ b/span.go
@@ -144,36 +144,56 @@ func (span *span) EndSpan() {
 }
 
 func (span *span) Inject(writer DistributedTracingContextWriter) {
-	if span.eventOverflow > 0 {
-		return
+	// The trace context is written even when the span has overflowed
+	// (spanMaxEventDepth/spanMaxEventSequence exceeded). Overflow limits
+	// profiling detail; it is not a sampling decision. Skipping the headers
+	// makes the downstream start a new trace and silently cuts the call chain.
+	//
+	// se is nil while overflowed: the overflowed event was never pushed, so
+	// there is nothing to record the link on - peek() would hand back an
+	// ancestor event that did not make this call.
+	var se *spanEvent
+	if span.eventOverflow == 0 {
+		if cur, ok := span.eventStack.peek(); ok {
+			se = cur
+		} else {
+			Log("span").Warnf("abnormal span - has no event")
+		}
 	}
-	if se, ok := span.eventStack.peek(); ok {
-		writer.Set(HeaderTraceId, span.txId.String())
 
-		nextSpanId := se.generateNextSpanId()
-		writer.Set(HeaderSpanId, strconv.FormatInt(nextSpanId, 10))
+	writer.Set(HeaderTraceId, span.txId.String())
 
-		writer.Set(HeaderParentSpanId, strconv.FormatInt(span.spanId, 10))
-		writer.Set(HeaderFlags, strconv.Itoa(span.flags))
-		writer.Set(HeaderParentApplicationName, span.agent.appName)
-		writer.Set(HeaderParentApplicationType, strconv.Itoa(int(span.agent.appType)))
-		writer.Set(HeaderParentApplicationNamespace, "")
+	// Overflowed: the next span id is generated but not recorded, so the
+	// downstream still joins this transaction under this span as its parent.
+	// Only the caller-side event->span link is lost, along with the event.
+	nextSpanId := generateSpanId()
+	if se != nil {
+		nextSpanId = se.generateNextSpanId()
+	}
+	writer.Set(HeaderSpanId, strconv.FormatInt(nextSpanId, 10))
 
-		// Propagate this agent's serviceName so downstream records it as the
-		// parent serviceName. Only set when present (v4), matching the Java
-		// agent's "serviceName != NOT_SET" guard; v1/v3 emit no such header.
-		if span.agent.serviceName != "" {
-			writer.Set(HeaderParentServiceName, span.agent.serviceName)
-		}
+	writer.Set(HeaderParentSpanId, strconv.FormatInt(span.spanId, 10))
+	writer.Set(HeaderFlags, strconv.Itoa(span.flags))
+	writer.Set(HeaderParentApplicationName, span.agent.appName)
+	writer.Set(HeaderParentApplicationType, strconv.Itoa(int(span.agent.appType)))
+	writer.Set(HeaderParentApplicationNamespace, "")
 
+	// Propagate this agent's serviceName so downstream records it as the
+	// parent serviceName. Only set when present (v4), matching the Java
+	// agent's "serviceName != NOT_SET" guard; v1/v3 emit no such header.
+	if span.agent.serviceName != "" {
+		writer.Set(HeaderParentServiceName, span.agent.serviceName)
+	}
+
+	destinationId := ""
+	if se != nil {
 		se.endPoint = se.destinationId
-		writer.Set(HeaderHost, se.destinationId)
+		destinationId = se.destinationId
+		writer.Set(HeaderHost, destinationId)
+	}
 
-		if IsTraceLogLevelEnabled() {
-			Log("span").Tracef("span inject: %v, %d, %d, %s", span.txId, nextSpanId, span.spanId, se.destinationId)
-		}
-	} else {
-		Log("span").Warnf("abnormal span - has no event")
+	if IsTraceLogLevelEnabled() {
+		Log("span").Tracef("span inject: %v, %d, %d, %s", span.txId, nextSpanId, span.spanId, destinationId)
 	}
 }
 

--- a/span_test.go
+++ b/span_test.go
@@ -127,6 +127,51 @@ func Test_span_Inject(t *testing.T) {
 	}
 }
 
+func Test_span_Inject_EventOverflow(t *testing.T) {
+	// Overflow limits profiling detail; it is not a sampling decision. The
+	// trace context must still be written or the downstream starts a new
+	// trace and the call chain is cut here.
+	tests := []struct {
+		name     string
+		overflow func(s *span)
+	}{
+		{"depth overflow - ancestor event left on the stack", func(s *span) {
+			s.agent.config.spanMaxEventDepth = 2
+			s.NewSpanEvent("t1")
+			s.NewSpanEvent("t2")
+		}},
+		{"sequence overflow - empty stack", func(s *span) {
+			s.agent.config.spanMaxEventSequence = 1
+			s.NewSpanEvent("t1").EndSpanEvent()
+			s.NewSpanEvent("t2")
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := defaultTestSpan()
+			s.spanId = int64(12345)
+			s.txId = TransactionId{AgentId: "t123456", StartTime: int64(12345), Sequence: int64(1)}
+			tt.overflow(s)
+			assert.Equal(t, s.eventOverflow, 1, "eventOverflow")
+
+			m := make(map[string]string)
+			s.Inject(&DistributedTracingContextMap{m})
+
+			assert.Equal(t, m[HeaderTraceId], s.txId.String(), "HeaderTraceId")
+			assert.Equal(t, m[HeaderParentSpanId], "12345", "HeaderParentSpanId")
+			assert.NotEmpty(t, m[HeaderSpanId], "HeaderSpanId")
+			assert.NotEqual(t, m[HeaderSpanId], m[HeaderParentSpanId], "nextSpanId != spanId")
+
+			// the dropped event carries no link back, and an ancestor event
+			// must not be credited with a call it did not make
+			if se, ok := s.eventStack.peek(); ok {
+				assert.Equal(t, se.nextSpanId, int64(0), "ancestor event nextSpanId")
+			}
+		})
+	}
+}
+
 func Test_span_NewSpanEvent(t *testing.T) {
 	type args struct {
 		operationName string


### PR DESCRIPTION
Fixes #124.

### Problem

`(*span).Inject()` returned before writing any header once the span's call stack had overflowed:

```go
if span.eventOverflow > 0 {
	return
}
```

After a span crosses `Span.MaxCallStackDepth` (64) or `Span.MaxCallStackSequence` (5000), its outgoing calls carried no `Pinpoint-TraceID` / `Pinpoint-SpanID` / `Pinpoint-pSpanID`. The downstream agent started a new transaction and the call chain was cut there.

Overflow limits how much profiling detail one span records; it is not a sampling decision. The span is still sampled and still reported — only the events past the limit are dropped.

### Change

The early return is gone and the context is always written. Removing it alone is not enough, though: while overflowed there is no current span event to work with, since `NewSpanEvent` only increments `eventOverflow` and never pushes. So `Inject` now treats "overflowed" as "no current event" and `eventStack.peek()` is consulted only when the span has not overflowed — otherwise it would hand back an ancestor event that did not make this call, and recording `nextSpanId` on it would fabricate a link in the call tree.

With no current event:

- TraceID / SpanID / pSpanID / Flags / parent-application headers are written as usual, so the downstream joins the transaction as a child of this span;
- the next span id is generated but not recorded on any event — the caller-side event->span link is the detail the overflow already dropped;
- `Pinpoint-Host` is omitted, since `SetDestination()` is a no-op while overflowed and there is no destination to send.

The `abnormal span - has no event` warning still fires for a genuinely empty stack, but no longer for the overflow case, which is expected.

### Test

`Test_span_Inject_EventOverflow` covers both ways a span overflows:

- depth overflow, where an ancestor event is left on the stack;
- sequence overflow, where the stack is empty.

Both assert that `Pinpoint-TraceID`, `Pinpoint-SpanID` and `Pinpoint-pSpanID` are populated, and that the ancestor event is not credited with a `nextSpanId` it did not generate.

`go test ./...` passes.
