### PR TITLE
[#129] Bound agent shutdown

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -118,6 +118,13 @@ const (
 	defaultSpanBatchCollectDeadline       = 500
 	defaultSpanBatchMaxConcurrentRequests = 10
 
+	// shutdownTimeout bounds how long Shutdown waits for the worker goroutines
+	// to drain their queues before abandoning them.
+	shutdownTimeout = 3 * time.Second
+	// connectGraceTimeout bounds how long Shutdown waits for an in-progress
+	// agent registration, in case Shutdown was called too early.
+	connectGraceTimeout = 1 * time.Second
+
 	maxSqlSize = 64 * 1024
 )
 
@@ -240,6 +247,7 @@ func (agent *agent) connectGrpcServer() {
 	}
 
 	agent.enable.Store(true)
+	agent.workerWg.Add(8)
 	go agent.sendPingWorker()
 	if agent.config.Bool(CfgSpanBatchEnable) {
 		go agent.sendSpanBatchWorker()
@@ -252,12 +260,32 @@ func (agent *agent) connectGrpcServer() {
 	go agent.collectUrlStatWorker()
 	go agent.sendUrlStatWorker()
 	go agent.sendStatsWorker()
-	agent.workerWg.Add(8)
+}
+
+// waitTimeout waits for wg and reports whether it completed within timeout.
+func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
 }
 
 func (agent *agent) Shutdown() {
-	// get delay in case shutdown was called too early
-	time.Sleep(1 * time.Second)
+	// Give an in-progress registration a moment to finish, in case shutdown was
+	// called too early. A registered agent has already released connectWg, so
+	// the normal shutdown path pays nothing here.
+	waitTimeout(&agent.connectWg, connectGraceTimeout)
 
 	agent.shutdown.Store(true)
 	Log("agent").Infof("shutdown pinpoint agent")
@@ -293,7 +321,11 @@ func (agent *agent) Shutdown() {
 		agent.urlStatTicker.Stop()
 		agent.urlStatDone <- true
 	}
-	agent.workerWg.Wait()
+	// Bound the drain: a collector outage must not keep the process alive.
+	// Abandoned workers are unblocked by the connection close below.
+	if !waitTimeout(&agent.workerWg, shutdownTimeout) {
+		Log("agent").Warnf("shutdown timeout(%v) exceeded, abandon in-flight workers", shutdownTimeout)
+	}
 
 	if agent.agentGrpc != nil {
 		agent.agentGrpc.close()

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,6 +1,7 @@
 package pinpoint
 
 import (
+	"sync"
 	"testing"
 	"time"
 
@@ -230,4 +231,62 @@ func callBoolWithTimeout(t *testing.T, name string, fn func() bool) bool {
 		t.Fatalf("%s blocked", name)
 		return false
 	}
+}
+
+func Test_waitTimeout(t *testing.T) {
+	var wg sync.WaitGroup
+	assert.True(t, waitTimeout(&wg, time.Second), "already done")
+
+	wg.Add(1)
+	start := time.Now()
+	assert.False(t, waitTimeout(&wg, 100*time.Millisecond), "timed out")
+	assert.Less(t, time.Since(start), 500*time.Millisecond, "returns at the deadline")
+
+	wg.Done()
+	assert.True(t, waitTimeout(&wg, time.Second), "done before the deadline")
+}
+
+// A worker stuck on an unreachable collector must not hold Shutdown forever.
+func Test_agent_ShutdownDeadline(t *testing.T) {
+	opts := []ConfigOption{
+		WithAppName("test"),
+		WithAgentId("testagent"),
+	}
+	c, _ := NewConfig(opts...)
+	c.offGrpc = true
+	a, _ := NewAgent(c)
+	agent := a.(*agent)
+	agent.enable.Store(true)
+
+	stuck := make(chan struct{})
+	defer close(stuck)
+	agent.workerWg.Add(1)
+	go func() {
+		defer agent.workerWg.Done()
+		<-stuck
+	}()
+
+	start := time.Now()
+	a.Shutdown()
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, shutdownTimeout, "waits for the deadline")
+	assert.Less(t, elapsed, shutdownTimeout+2*time.Second, "gives up at the deadline")
+}
+
+// The normal path must not pay the startup grace delay.
+func Test_agent_ShutdownNoStartupDelay(t *testing.T) {
+	opts := []ConfigOption{
+		WithAppName("test"),
+		WithAgentId("testagent"),
+	}
+	c, _ := NewConfig(opts...)
+	c.offGrpc = true
+	a, _ := NewAgent(c)
+	a.(*agent).enable.Store(true)
+
+	start := time.Now()
+	a.Shutdown()
+
+	assert.Less(t, time.Since(start), connectGraceTimeout, "no unconditional sleep")
 }


### PR DESCRIPTION
Fixes #129.

`Shutdown()` slept 1s unconditionally and then waited on `workerWg` with no deadline: every normal shutdown paid a second it did not need, and a stuck or unreachable collector kept the process from exiting.

## Changes

### 1. The unconditional sleep becomes a conditional wait

```go
-	// get delay in case shutdown was called too early
-	time.Sleep(1 * time.Second)
+	waitTimeout(&agent.connectWg, connectGraceTimeout)
```

The sleep existed so that a `Shutdown()` called right after `NewAgent()` would not abort the in-progress registration (`registerAgentWithRetry` loops on `for !agent.shutdown`) and fall straight into the `if !agent.enable { return }` early exit without flushing anything.

`connectWg` already tracks exactly that condition, and a registered agent released it long ago — so the normal path now costs nothing, while a shutdown called too early still gets the same 1s grace it gets today. Waiting on the `WaitGroup` rather than polling `agent.enable` also keeps this free of the data race in #123 (addressed separately in #126).

### 2. The worker drain gets a deadline

```go
-	agent.workerWg.Wait()
+	if !waitTimeout(&agent.workerWg, shutdownTimeout) {
+		Log("agent").Warnf("shutdown timeout(%v) exceeded, abandon in-flight workers", shutdownTimeout)
+	}
```

Fixed at 3s, matching the C++ agent's `span_shutdown_await_timeout` / `meta_shutdown_await_timeout` defaults. The `grpcConn.Close()` calls that already follow fail the in-flight RPCs and unblock the abandoned workers — the same escalation C++ performs with `TryCancel`. They were previously unreachable while a worker was stuck, since they sit after the wait.

Both timeouts are constants, not configuration options.

### 3. `workerWg.Add(8)` moved above the goroutines it counts

`Add` must happen before the counter can reach zero. Beyond the latent `sync: negative WaitGroup counter` panic, this is load-bearing for the change above: a racing `Add` would let the bounded wait observe an empty group and report a clean drain.

## Tests

- `Test_agent_ShutdownDeadline` — a worker that never returns (the collector-outage case) must not hold `Shutdown()` past the deadline. Against the pre-fix code this hangs indefinitely.
- `Test_agent_ShutdownNoStartupDelay` — the normal path returns in less than `connectGraceTimeout`. Against the pre-fix code it takes the full 1s and fails.
- `Test_waitTimeout` — both branches of the helper.

Independent confirmation that the 1s is gone from the normal path — an existing test that only constructs and shuts down an agent:

```
main @ 3f11e52:   --- PASS: Test_agent_NewAgent (1.00s)
this branch:      --- PASS: Test_agent_NewAgent (0.00s)
```

```
$ go test -race ./...
ok  	github.com/pinpoint-apm/pinpoint-go-agent	9.966s
```

(The suite is ~3s longer than before because `Test_agent_ShutdownDeadline` waits out the real deadline.)
