### PR TITLE
[#131] Publish config reloads as an atomic snapshot

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -18,6 +18,7 @@ import (
 func init() {
 	initLogger()
 	initConfig()
+	initNoopAgent()
 	initGoroutine()
 	globalAgent = NoopAgent()
 }
@@ -40,7 +41,6 @@ type agent struct {
 	metaChan    chan interface{}
 	urlStatChan chan *urlStat
 	statChan    chan *pb.PStatMessage
-	sampler     traceSampler
 
 	errorCache  *lru.Cache
 	errorIdGen  int32
@@ -195,9 +195,6 @@ func NewAgent(config *Config) (Agent, error) {
 		return NoopAgent(), err
 	}
 
-	agent.newSampler()
-	samplingOpts := []string{CfgSamplingType, CfgSamplingCounterRate, CfgSamplingPercentRate, CfgSamplingNewThroughput, CfgSamplingContinueThroughput}
-	config.AddReloadCallback(samplingOpts, agent.newSampler)
 	config.AddReloadCallback([]string{CfgLogLevel}, logger.reloadLevel)
 	config.AddReloadCallback([]string{CfgLogOutput, CfgLogMaxSize}, logger.reloadOutput)
 
@@ -207,23 +204,6 @@ func NewAgent(config *Config) (Agent, error) {
 	}
 	globalAgent = agent
 	return agent, nil
-}
-
-func (agent *agent) newSampler() {
-	config := agent.config
-	var baseSampler sampler
-	if config.String(CfgSamplingType) == samplingTypeCounter {
-		baseSampler = newRateSampler(config.Int(CfgSamplingCounterRate))
-	} else {
-		baseSampler = newPercentSampler(config.Float(CfgSamplingPercentRate))
-	}
-
-	if config.Int(CfgSamplingNewThroughput) > 0 || config.Int(CfgSamplingContinueThroughput) > 0 {
-		agent.sampler = newThroughputLimitTraceSampler(baseSampler, config.Int(CfgSamplingNewThroughput),
-			config.Int(CfgSamplingContinueThroughput))
-	} else {
-		agent.sampler = newBasicTraceSampler(baseSampler)
-	}
 }
 
 func (agent *agent) connectGrpcServer() {
@@ -361,11 +341,12 @@ func (agent *agent) NewSpanTracerWithReader(operation string, rpcName string, re
 		return newUnSampledSpan(agent, rpcName)
 	}
 
+	sampler := agent.config.load().sampler
 	tid := reader.Get(HeaderTraceId)
 	if tid == "" {
-		return agent.samplingSpan(func() bool { return agent.sampler.isNewSampled() }, operation, rpcName, reader)
+		return agent.samplingSpan(func() bool { return sampler.isNewSampled() }, operation, rpcName, reader)
 	} else {
-		return agent.samplingSpan(func() bool { return agent.sampler.isContinueSampled() }, operation, rpcName, reader)
+		return agent.samplingSpan(func() bool { return sampler.isContinueSampled() }, operation, rpcName, reader)
 	}
 }
 
@@ -715,7 +696,7 @@ func (agent *agent) cacheSpanApi(descriptor string, apiType int) int32 {
 }
 
 func (agent *agent) enqueueExceptionMeta(span *span) {
-	if !agent.enable.Load() || !agent.config.errorTraceCallStack {
+	if !agent.enable.Load() || !span.cfg.errorTraceCallStack {
 		return
 	}
 
@@ -787,7 +768,7 @@ func (agent *agent) sendUrlStatWorker() {
 			Log("agent").Infof("end send uri stat goroutine")
 			return
 		case <-agent.urlStatTicker.C:
-			if agent.config.collectUrlStat {
+			if agent.config.load().collectUrlStat {
 				snapshot := agent.takeUrlStatSnapshot()
 				agent.enqueueStat(makePAgentUriStat(snapshot))
 			}
@@ -870,7 +851,6 @@ func NewTestAgent(config *Config, t *testing.T) (Agent, error) {
 	agent.sqlCache, _ = lru.New(cacheSize)
 	agent.sqlUidCache, _ = lru.New(cacheSize)
 	agent.apiCache, _ = lru.New(cacheSize)
-	agent.newSampler()
 
 	agent.agentGrpc = newMockAgentGrpc(agent, t)
 	//agent.spanGrpc = newMockSpanGrpc(agent, t)

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -30,8 +30,8 @@ import (
 // long-lived span never trips the overflow path mid-benchmark.
 func benchAgent() *agent {
 	cfg := defaultConfig()
-	cfg.spanMaxEventSequence = math.MaxInt32
-	cfg.spanMaxEventDepth = math.MaxInt32
+	cfg.Set(CfgSpanMaxCallStackSequence, math.MaxInt32)
+	cfg.Set(CfgSpanMaxCallStackDepth, math.MaxInt32)
 
 	// Keep trace/debug guards short-circuited (the production-relevant condition
 	// for the hot path) regardless of any level a previously run unit test left
@@ -44,9 +44,7 @@ func benchAgent() *agent {
 }
 
 func benchSpan(a *agent) *span {
-	s := defaultSpan()
-	s.agent = a
-	return s
+	return defaultSpan(a)
 }
 
 // startDrain consumes spanChan/metaChan in the background so enqueue stays on

--- a/config.go
+++ b/config.go
@@ -3,8 +3,11 @@ package pinpoint
 import (
 	"math"
 	"os"
+	"reflect"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cast"
@@ -83,7 +86,6 @@ type cfgMapItem struct {
 	cmdKey       string
 	envKey       string
 	dynamic      bool
-	oldValue     interface{}
 }
 
 var (
@@ -160,15 +162,34 @@ func envName(cfgName string) string {
 }
 
 // Config holds agent configuration, for passing to NewAgent.
+//
+// Everything a config file reload can change lives in an immutable
+// configSnapshot behind an atomic pointer. The Config value itself is handed
+// out by GetConfig and held for the process lifetime, so its identity is
+// stable; only the snapshot it points at is replaced.
 type Config struct {
-	cfgMap         map[string]*cfgMapItem
+	// mu guards the cfgMap staging area and the reload callback list. Readers
+	// never take it - they load the published snapshot instead - so it is only
+	// ever contended between startup and the config watcher goroutine.
+	mu       sync.Mutex
+	cfgMap   map[string]*cfgMapItem
+	callback []reloadCallback
+	snapshot atomic.Pointer[configSnapshot]
+
 	containerCheck bool
 	useNewLogOpt   bool
 	offGrpc        bool //for test
 	objName        *objectName
+}
 
-	//dynamic config
-	callback             []reloadCallback
+// configSnapshot is the immutable view of the config that request goroutines
+// read: the option values plus every component derived from them. A reload
+// builds a whole new snapshot and publishes it with a single atomic store, so
+// an in-flight request can never observe a half-applied reload.
+type configSnapshot struct {
+	values  map[string]interface{}
+	sampler traceSampler
+
 	collectUrlStat       bool  // CfgHttpUrlStatEnable
 	urlStatLimitSize     int   // CfgHttpUrlStatLimitSize
 	urlStatWithMethod    bool  // CfgHttpUrlStatWithMethod
@@ -184,6 +205,20 @@ type Config struct {
 	errorCallStackDepth  int   // CfgErrorCallStackDepth
 }
 
+// emptyConfigSnapshot stands in for a Config that was built by hand instead of
+// by NewConfig, so its accessors keep returning zero values rather than panic.
+var emptyConfigSnapshot = &configSnapshot{}
+
+// load returns the currently published snapshot. Callers that must see a
+// consistent set of options - a span, a single request - load it once and keep
+// the returned pointer instead of calling load per field.
+func (config *Config) load() *configSnapshot {
+	if snapshot := config.snapshot.Load(); snapshot != nil {
+		return snapshot
+	}
+	return emptyConfigSnapshot
+}
+
 // ConfigOption represents an option that can be passed to NewConfig.
 type ConfigOption func(*Config)
 
@@ -194,49 +229,57 @@ func GetConfig() *Config {
 
 // Set stores the specified configuration item value.
 func (config *Config) Set(cfgName string, value interface{}) {
+	config.mu.Lock()
+	defer config.mu.Unlock()
+
 	if v, ok := config.cfgMap[cfgName]; ok {
 		v.value = value
+		config.publish()
 	}
 }
 
 // Int returns an integer value for the specified configuration item.
 func (config *Config) Int(cfgName string) int {
-	if v, ok := config.cfgMap[cfgName]; ok {
-		return cast.ToInt(v.value)
-	}
-	return 0
+	return cast.ToInt(config.load().values[cfgName])
 }
 
 // Float returns a float value for the specified configuration item.
 func (config *Config) Float(cfgName string) float64 {
-	if v, ok := config.cfgMap[cfgName]; ok {
-		return cast.ToFloat64(v.value)
-	}
-	return 0
+	return cast.ToFloat64(config.load().values[cfgName])
 }
 
 // String returns a string value for the specified configuration item.
 func (config *Config) String(cfgName string) string {
-	if v, ok := config.cfgMap[cfgName]; ok {
-		return cast.ToString(v.value)
-	}
-	return ""
+	return cast.ToString(config.load().values[cfgName])
 }
 
 // StringSlice returns a string slice value for the specified configuration item.
+// The returned slice belongs to the published snapshot - copy it before writing.
 func (config *Config) StringSlice(cfgName string) []string {
-	if v, ok := config.cfgMap[cfgName]; ok {
-		return cast.ToStringSlice(v.value)
-	}
-	return []string{}
+	return cast.ToStringSlice(config.load().values[cfgName])
 }
 
 // Bool returns a boolean value for the specified configuration item.
 func (config *Config) Bool(cfgName string) bool {
+	return cast.ToBool(config.load().values[cfgName])
+}
+
+// staged reads a value straight out of the cfgMap staging area. Only the
+// snapshot build path may use it: it bypasses the published snapshot, and the
+// caller must hold config.mu.
+func (config *Config) staged(cfgName string) interface{} {
 	if v, ok := config.cfgMap[cfgName]; ok {
-		return cast.ToBool(v.value)
+		return v.value
 	}
-	return false
+	return nil
+}
+
+func (config *Config) stagedInt(cfgName string) int {
+	return cast.ToInt(config.staged(cfgName))
+}
+
+func (config *Config) stagedString(cfgName string) string {
+	return cast.ToString(config.staged(cfgName))
 }
 
 // NewConfig creates a Config populated with default settings, command line arguments,
@@ -275,31 +318,35 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 	cmdEnvViper.SetEnvPrefix("pinpoint_go")
 	cmdEnvViper.AutomaticEnv()
 
+	// loadConfigFile starts the file watcher, so everything past this point can
+	// run concurrently with a reload and has to hold the lock.
 	cfgFileViper := config.loadConfigFile(cmdEnvViper)
+
+	config.mu.Lock()
+	defer config.mu.Unlock()
+
 	profileViper := config.loadProfile(cmdEnvViper, cfgFileViper)
 	config.loadConfig(cmdEnvViper, cfgFileViper, profileViper)
-
-	config.callback = make([]reloadCallback, 0)
-	config.applyDynamicConfig()
 
 	if config.containerCheck {
 		config.cfgMap[CfgIsContainerEnv].value = isContainerEnv()
 	}
-	if config.Int(CfgSpanQueueSize) < 1 {
+	if config.stagedInt(CfgSpanQueueSize) < 1 {
 		config.cfgMap[CfgSpanQueueSize].value = defaultQueueSize
 	}
-	if config.Int(CfgSpanBatchSize) < 1 {
+	if config.stagedInt(CfgSpanBatchSize) < 1 {
 		config.cfgMap[CfgSpanBatchSize].value = defaultSpanBatchSize
 	}
-	if config.Int(CfgSpanBatchFlushInterval) < 1 {
+	if config.stagedInt(CfgSpanBatchFlushInterval) < 1 {
 		config.cfgMap[CfgSpanBatchFlushInterval].value = defaultSpanBatchFlushInterval
 	}
-	if config.Int(CfgSpanBatchCollectDeadline) < 1 {
+	if config.stagedInt(CfgSpanBatchCollectDeadline) < 1 {
 		config.cfgMap[CfgSpanBatchCollectDeadline].value = defaultSpanBatchCollectDeadline
 	}
-	if config.Int(CfgSpanBatchMaxConcurrentRequests) < 1 {
+	if config.stagedInt(CfgSpanBatchMaxConcurrentRequests) < 1 {
 		config.cfgMap[CfgSpanBatchMaxConcurrentRequests].value = defaultSpanBatchMaxConcurrentRequests
 	}
+	config.publish()
 
 	return config, nil
 }
@@ -321,19 +368,11 @@ func defaultConfig() *Config {
 	}
 
 	config.containerCheck = true
-	config.collectUrlStat = false
-	config.urlStatLimitSize = 1024
-	config.urlStatWithMethod = false
-	config.sqlTraceBindValue = true
-	config.sqlMaxBindValueSize = 1024
-	config.sqlTraceCommit = true
-	config.sqlTraceRollback = true
-	config.sqlTraceQueryStat = false
-	config.spanEventChunkSize = defaultEventChunkSize
-	config.spanMaxEventDepth = defaultEventDepth
-	config.spanMaxEventSequence = defaultEventSequence
-	config.errorTraceCallStack = false
-	config.errorCallStackDepth = 32
+	config.callback = make([]reloadCallback, 0)
+
+	config.mu.Lock()
+	defer config.mu.Unlock()
+	config.publish()
 
 	return config
 }
@@ -471,66 +510,123 @@ func (config *Config) checkNameAndID() error {
 	if err != nil {
 		return err
 	}
+	config.mu.Lock()
+	defer config.mu.Unlock()
+
 	config.objName = objName
 	config.cfgMap[CfgAgentID].value = objName.agentID
 	config.cfgMap[CfgAgentName].value = objName.agentName
 	config.cfgMap[CfgServiceName].value = objName.serviceName
+	config.publish()
 	return nil
 }
 
-func (config *Config) applyDynamicConfig() {
-	sampleType := strings.ToUpper(strings.TrimSpace(config.String(CfgSamplingType)))
+var samplingOpts = []string{
+	CfgSamplingType, CfgSamplingCounterRate, CfgSamplingPercentRate,
+	CfgSamplingNewThroughput, CfgSamplingContinueThroughput,
+}
+
+// publish normalizes the staged cfgMap values and installs the result as a new
+// snapshot with a single atomic store. Everything derived from the config is
+// built here so that one store makes the whole generation visible at once.
+// The caller must hold config.mu.
+func (config *Config) publish() {
+	sampleType := strings.ToUpper(strings.TrimSpace(config.stagedString(CfgSamplingType)))
 	if sampleType != samplingTypeCounter && sampleType != samplingTypePercent {
 		config.cfgMap[CfgSamplingType].value = samplingTypeCounter
 		config.cfgMap[CfgSamplingCounterRate].value = 0
 	}
 
-	maxBind := config.Int(CfgSQLMaxBindValueSize)
+	maxBind := config.stagedInt(CfgSQLMaxBindValueSize)
 	if maxBind > 1024 {
 		config.cfgMap[CfgSQLMaxBindValueSize].value = 1024
 	} else if maxBind < 0 {
 		config.cfgMap[CfgSQLTraceBindValue].value = false
 		config.cfgMap[CfgSQLMaxBindValueSize].value = 0
 	}
-	config.sqlTraceBindValue = config.Bool(CfgSQLTraceBindValue)
-	config.sqlMaxBindValueSize = config.Int(CfgSQLMaxBindValueSize)
-	config.sqlTraceCommit = config.Bool(CfgSQLTraceCommit)
-	config.sqlTraceRollback = config.Bool(CfgSQLTraceRollback)
-	config.sqlTraceQueryStat = config.Bool(CfgSQLTraceQueryStat)
 
-	eventChunkSize := config.Int(CfgSpanEventChunkSize)
-	if eventChunkSize < 1 {
-		eventChunkSize = defaultEventChunkSize
+	if config.stagedInt(CfgSpanEventChunkSize) < 1 {
+		config.cfgMap[CfgSpanEventChunkSize].value = defaultEventChunkSize
 	}
-	config.cfgMap[CfgSpanEventChunkSize].value = eventChunkSize
-	config.spanEventChunkSize = config.Int(CfgSpanEventChunkSize)
 
-	maxDepth := config.Int(CfgSpanMaxCallStackDepth)
+	maxDepth := config.stagedInt(CfgSpanMaxCallStackDepth)
 	if maxDepth == -1 {
 		maxDepth = math.MaxInt32
 	} else if maxDepth < minEventDepth {
 		maxDepth = minEventDepth
 	}
 	config.cfgMap[CfgSpanMaxCallStackDepth].value = maxDepth
-	config.spanMaxEventDepth = int32(config.Int(CfgSpanMaxCallStackDepth))
 
-	maxSeq := config.Int(CfgSpanMaxCallStackSequence)
+	maxSeq := config.stagedInt(CfgSpanMaxCallStackSequence)
 	if maxSeq == -1 {
 		maxSeq = math.MaxInt32
 	} else if maxSeq < minEventSequence {
 		maxSeq = minEventSequence
 	}
 	config.cfgMap[CfgSpanMaxCallStackSequence].value = maxSeq
-	config.spanMaxEventSequence = int32(config.Int(CfgSpanMaxCallStackSequence))
 
-	if config.Int(CfgLogMaxSize) < 1 {
+	if config.stagedInt(CfgLogMaxSize) < 1 {
 		config.cfgMap[CfgLogMaxSize].value = 10
 	}
-	config.collectUrlStat = config.Bool(CfgHttpUrlStatEnable)
-	config.urlStatLimitSize = config.Int(CfgHttpUrlStatLimitSize)
-	config.urlStatWithMethod = config.Bool(CfgHttpUrlStatWithMethod)
-	config.errorTraceCallStack = config.Bool(CfgErrorTraceCallStack)
-	config.errorCallStackDepth = config.Int(CfgErrorCallStackDepth)
+
+	values := make(map[string]interface{}, len(config.cfgMap))
+	for k, v := range config.cfgMap {
+		values[k] = v.value
+	}
+
+	snapshot := &configSnapshot{
+		values:               values,
+		collectUrlStat:       cast.ToBool(values[CfgHttpUrlStatEnable]),
+		urlStatLimitSize:     cast.ToInt(values[CfgHttpUrlStatLimitSize]),
+		urlStatWithMethod:    cast.ToBool(values[CfgHttpUrlStatWithMethod]),
+		sqlTraceBindValue:    cast.ToBool(values[CfgSQLTraceBindValue]),
+		sqlMaxBindValueSize:  cast.ToInt(values[CfgSQLMaxBindValueSize]),
+		sqlTraceCommit:       cast.ToBool(values[CfgSQLTraceCommit]),
+		sqlTraceRollback:     cast.ToBool(values[CfgSQLTraceRollback]),
+		sqlTraceQueryStat:    cast.ToBool(values[CfgSQLTraceQueryStat]),
+		spanEventChunkSize:   cast.ToInt(values[CfgSpanEventChunkSize]),
+		spanMaxEventDepth:    cast.ToInt32(values[CfgSpanMaxCallStackDepth]),
+		spanMaxEventSequence: cast.ToInt32(values[CfgSpanMaxCallStackSequence]),
+		errorTraceCallStack:  cast.ToBool(values[CfgErrorTraceCallStack]),
+		errorCallStackDepth:  cast.ToInt(values[CfgErrorCallStackDepth]),
+	}
+	snapshot.sampler = newTraceSampler(config.load(), values)
+
+	config.snapshot.Store(snapshot)
+}
+
+// newTraceSampler carries the previous sampler over when no sampling option
+// changed, so an unrelated reload does not reset the throughput limiter's
+// counters.
+func newTraceSampler(prev *configSnapshot, values map[string]interface{}) traceSampler {
+	if prev != nil && prev.sampler != nil && sameValues(prev.values, values, samplingOpts) {
+		return prev.sampler
+	}
+
+	var baseSampler sampler
+	if cast.ToString(values[CfgSamplingType]) == samplingTypeCounter {
+		baseSampler = newRateSampler(cast.ToInt(values[CfgSamplingCounterRate]))
+	} else {
+		baseSampler = newPercentSampler(cast.ToFloat64(values[CfgSamplingPercentRate]))
+	}
+
+	newTps := cast.ToInt(values[CfgSamplingNewThroughput])
+	continueTps := cast.ToInt(values[CfgSamplingContinueThroughput])
+	if newTps > 0 || continueTps > 0 {
+		return newThroughputLimitTraceSampler(baseSampler, newTps, continueTps)
+	}
+	return newBasicTraceSampler(baseSampler)
+}
+
+// sameValues compares config values with DeepEqual: a value can be a slice
+// (CfgStringSlice options), and == panics on those.
+func sameValues(a, b map[string]interface{}, keys []string) bool {
+	for _, k := range keys {
+		if !reflect.DeepEqual(a[k], b[k]) {
+			return false
+		}
+	}
+	return true
 }
 
 type reloadCallback struct {
@@ -540,6 +636,9 @@ type reloadCallback struct {
 
 // AddReloadCallback adds a callback function will be called after reloading config file.
 func (config *Config) AddReloadCallback(optNames []string, callback func()) {
+	config.mu.Lock()
+	defer config.mu.Unlock()
+
 	config.callback = append(config.callback, reloadCallback{optNames, callback})
 }
 
@@ -549,48 +648,56 @@ func (config *Config) reloadConfig(cfgFileViper *viper.Viper) {
 		return
 	}
 
+	config.mu.Lock()
 	profileViper := config.loadProfile(viper.New(), cfgFileViper)
-	config.loadDynamicConfig(cfgFileViper, profileViper)
-	config.applyDynamicConfig()
+	changed := config.loadDynamicConfig(cfgFileViper, profileViper)
+	config.publish()
+	// Callbacks read the config they were just given a new generation of, and
+	// may register further callbacks, so run them off a copy with the lock
+	// released.
+	callback := make([]reloadCallback, len(config.callback))
+	copy(callback, config.callback)
+	config.mu.Unlock()
 
-	for _, cb := range config.callback {
-		cb.do(config)
+	for _, cb := range callback {
+		cb.do(changed)
 	}
 }
 
-func (config *Config) loadDynamicConfig(cfgFileViper *viper.Viper, profileViper *viper.Viper) {
+// loadDynamicConfig restages the dynamic options from the config file and
+// returns the set of option names whose value actually changed.
+func (config *Config) loadDynamicConfig(cfgFileViper *viper.Viper, profileViper *viper.Viper) map[string]bool {
+	changed := make(map[string]bool)
+
 	sortKeys := make([]string, 0)
 	for k := range config.cfgMap {
 		sortKeys = append(sortKeys, k)
 	}
 	sort.Strings(sortKeys)
 	for _, k := range sortKeys {
-		if v := config.cfgMap[k]; v.dynamic {
-			v.oldValue = nil
-			if profileViper.IsSet(k) {
-				config.reloadFinalValue(k, v, profileViper)
-			} else if cfgFileViper.IsSet(k) {
-				config.reloadFinalValue(k, v, cfgFileViper)
-			}
+		v := config.cfgMap[k]
+		if !v.dynamic {
+			continue
+		}
+
+		oldValue := v.value
+		if profileViper.IsSet(k) {
+			config.setFinalValue(k, v, profileViper.Get(k))
+		} else if cfgFileViper.IsSet(k) {
+			config.setFinalValue(k, v, cfgFileViper.Get(k))
+		} else {
+			continue
+		}
+		if !reflect.DeepEqual(oldValue, v.value) {
+			changed[k] = true
 		}
 	}
+	return changed
 }
 
-func (config *Config) reloadFinalValue(cfgName string, item *cfgMapItem, viper *viper.Viper) {
-	item.oldValue = item.value
-	config.setFinalValue(cfgName, item, viper.Get(cfgName))
-}
-
-func (config *Config) isReloaded(cfgName string) bool {
-	if item, ok := config.cfgMap[cfgName]; ok {
-		return item.oldValue != nil && item.oldValue != item.value
-	}
-	return false
-}
-
-func (cb reloadCallback) do(config *Config) {
+func (cb reloadCallback) do(changed map[string]bool) {
 	for _, k := range cb.cfgNames {
-		if config.isReloaded(k) {
+		if changed[k] {
 			cb.callback()
 			break
 		}
@@ -930,21 +1037,23 @@ func WithErrorCallStackDepth(depth int) ConfigOption {
 }
 
 func (config *Config) printConfigString() {
+	values := config.load().values
+
 	sortKeys := make([]string, 0)
-	for k := range config.cfgMap {
+	for k := range values {
 		sortKeys = append(sortKeys, k)
 	}
 	sort.Strings(sortKeys)
 
 	for _, k := range sortKeys {
 		if k == CfgApiKey {
-			if config.cfgMap[k].value == "" {
+			if values[k] == "" {
 				Log("config").Infof("%s = ", k)
 			} else {
 				Log("config").Infof("%s = ****", k)
 			}
 			continue
 		}
-		Log("config").Infof("%s = %v", k, config.cfgMap[k].value)
+		Log("config").Infof("%s = %v", k, values[k])
 	}
 }

--- a/config_race_test.go
+++ b/config_race_test.go
@@ -1,0 +1,124 @@
+package pinpoint
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+)
+
+// TestConfigReloadRace drives a config reload concurrently with the reads a
+// request goroutine performs, which is what the fsnotify watcher does in
+// production. Run it with -race: before the config was published as an
+// immutable snapshot, the reloader wrote Config's typed fields, cfgMap[k].value
+// and agent.sampler in place while spans and the generic accessors read them.
+func TestConfigReloadRace(t *testing.T) {
+	cfgFile := filepath.Join(t.TempDir(), "pinpoint-config.yaml")
+	writeCfgFile := func(i int) {
+		body := fmt.Sprintf(`
+Sampling:
+  Type: %s
+  CounterRate: %d
+  NewThroughput: %d
+SQL:
+  TraceBindValue: %t
+  MaxBindValueSize: %d
+  TraceQueryStat: %t
+Span:
+  MaxCallStackDepth: %d
+  MaxCallStackSequence: %d
+  EventChunkSize: %d
+Error:
+  TraceCallStack: %t
+  CallStackDepth: %d
+Http:
+  UrlStat:
+    Enable: %t
+    LimitSize: %d
+`,
+			[]string{samplingTypeCounter, samplingTypePercent}[i%2], 1+i%8, i%4,
+			i%2 == 0, 128+i%64, i%2 == 1,
+			8+i%32, 16+i%64, 4+i%16,
+			i%2 == 0, 8+i%16,
+			i%2 == 1, 512+i%256)
+		if err := os.WriteFile(cfgFile, []byte(body), 0o600); err != nil {
+			t.Error(err)
+		}
+	}
+	writeCfgFile(0)
+
+	// The reload is driven directly rather than through WithConfigFile so the
+	// test does not depend on fsnotify timing.
+	config, err := NewConfig(WithAppName("raceApp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	agent := newTestAgent(config)
+	conn := &sqlConn{config: config}
+
+	cfgFileViper := viper.New()
+	cfgFileViper.SetConfigFile(cfgFile)
+
+	done := make(chan struct{})
+	stopped := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // stands in for the fsnotify goroutine
+		defer wg.Done()
+		for i := 1; !stopped(); i++ {
+			writeCfgFile(i)
+			config.reloadConfig(cfgFileViper)
+		}
+	}()
+
+	wg.Add(1)
+	go func() { // AddReloadCallback races the reloader's walk of the callback list
+		defer wg.Done()
+		for i := 0; i < 50 && !stopped(); i++ {
+			config.AddReloadCallback([]string{CfgSamplingCounterRate}, func() {})
+			time.Sleep(time.Millisecond)
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { // request goroutines
+			defer wg.Done()
+			named := []driver.NamedValue{{Ordinal: 1, Value: "1"}}
+			for !stopped() {
+				_ = config.Bool(CfgSQLTraceBindValue)
+				_ = config.Int(CfgSpanMaxCallStackDepth)
+				_ = config.Float(CfgSamplingPercentRate)
+				_ = config.String(CfgSamplingType)
+				_ = config.StringSlice(CfgActiveProfile)
+				_ = conn.namedValueToString(named)
+
+				tracer := agent.NewSpanTracer("raceOp", "/race")
+				tracer.NewSpanEvent("evt")
+				tracer.SpanEvent().SetSQL("select * from t where id = ?", "1")
+				tracer.SpanEvent().SetError(errors.New("race error"))
+				tracer.EndSpanEvent()
+				tracer.AddMetric(MetricURLStat, &UrlStatEntry{Url: "/race", Method: "GET", Status: 200})
+				tracer.EndSpan()
+			}
+		}()
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}

--- a/config_test.go
+++ b/config_test.go
@@ -3,8 +3,10 @@ package pinpoint
 import (
 	"math"
 	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -643,4 +645,70 @@ func TestNewConfig_CmdLineArg(t *testing.T) {
 			assert.Equal(t, 100, c.Int(CfgErrorCallStackDepth), CfgErrorCallStackDepth)
 		})
 	}
+}
+
+func Test_reloadConfig(t *testing.T) {
+	const sliceOpt = "Test.StringSlice"
+
+	config, err := NewConfig(WithAppName("reloadApp"))
+	assert.NoError(t, err)
+
+	// The core registers no dynamic string slice option, but the http plugin
+	// does; inject one so the reload path is exercised with a slice value.
+	config.cfgMap[sliceOpt] = &cfgMapItem{
+		value:        []string{"before"},
+		defaultValue: []string{},
+		valueType:    CfgStringSlice,
+		dynamic:      true,
+	}
+
+	var reloadedSlice, reloadedDepth, reloadedUntouched int
+	config.AddReloadCallback([]string{sliceOpt}, func() { reloadedSlice++ })
+	config.AddReloadCallback([]string{CfgSpanMaxCallStackDepth}, func() { reloadedDepth++ })
+	config.AddReloadCallback([]string{CfgSQLTraceCommit}, func() { reloadedUntouched++ })
+
+	cfgFile := filepath.Join(t.TempDir(), "pinpoint-config.yaml")
+	body := `
+Test:
+  StringSlice:
+    - after
+    - /**/*.do
+Span:
+  MaxCallStackDepth: 12
+`
+	assert.NoError(t, os.WriteFile(cfgFile, []byte(body), 0o600))
+
+	cfgFileViper := viper.New()
+	cfgFileViper.SetConfigFile(cfgFile)
+	config.reloadConfig(cfgFileViper)
+
+	assert.Equal(t, []string{"after", "/**/*.do"}, config.StringSlice(sliceOpt))
+	assert.Equal(t, 12, config.Int(CfgSpanMaxCallStackDepth))
+	assert.Equal(t, int32(12), config.load().spanMaxEventDepth)
+	assert.Equal(t, 1, reloadedSlice)
+	assert.Equal(t, 1, reloadedDepth)
+	assert.Equal(t, 0, reloadedUntouched, "callback fired for an option the file did not change")
+
+	// Reloading the same file again changes nothing, so no callback fires.
+	config.reloadConfig(cfgFileViper)
+	assert.Equal(t, 1, reloadedSlice)
+	assert.Equal(t, 1, reloadedDepth)
+}
+
+func Test_reloadConfig_keepsSamplerWhenSamplingUnchanged(t *testing.T) {
+	config, err := NewConfig(WithAppName("reloadApp"), WithSamplingNewThroughput(10))
+	assert.NoError(t, err)
+
+	cfgFile := filepath.Join(t.TempDir(), "pinpoint-config.yaml")
+	assert.NoError(t, os.WriteFile(cfgFile, []byte("Span:\n  MaxCallStackDepth: 12\n"), 0o600))
+	cfgFileViper := viper.New()
+	cfgFileViper.SetConfigFile(cfgFile)
+
+	sampler := config.load().sampler
+	config.reloadConfig(cfgFileViper)
+	assert.Same(t, sampler, config.load().sampler, "unrelated reload rebuilt the sampler")
+
+	assert.NoError(t, os.WriteFile(cfgFile, []byte("Sampling:\n  NewThroughput: 20\n"), 0o600))
+	config.reloadConfig(cfgFileViper)
+	assert.NotSame(t, sampler, config.load().sampler, "sampling change did not rebuild the sampler")
 }

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -149,8 +149,7 @@ func Test_spanStream_sendSpan(t *testing.T) {
 			agent.spanGrpc = newMockSpanGrpc(agent, t)
 			stream := agent.spanGrpc.newSpanStreamWithRetry()
 
-			span := defaultSpan()
-			span.agent = agent
+			span := defaultSpan(agent)
 			span.NewSpanEvent("t1")
 			err := stream.sendSpan(span.newEventChunk(true))
 			assert.NoError(t, err, "sendSpan")
@@ -174,8 +173,7 @@ func Test_spanGrpc_sendSpanBatch(t *testing.T) {
 			agent := tt.args.agent
 			agent.spanGrpc = newMockSpanGrpc(agent, t)
 
-			span := defaultSpan()
-			span.agent = agent
+			span := defaultSpan(agent)
 			span.NewSpanEvent("t1")
 			agent.spanGrpc.sendSpanBatchAsync([]*spanChunk{span.newEventChunk(true)})
 			agent.spanGrpc.awaitInFlightSpanBatch()
@@ -291,9 +289,7 @@ func Test_statStream_sendStat(t *testing.T) {
 }
 
 func newTestSpanChunk(agent *agent) *spanChunk {
-	span := defaultSpan()
-	span.agent = agent
-	return span.newEventChunk(true)
+	return defaultSpan(agent).newEventChunk(true)
 }
 
 func Test_statStream_sendStatRetry(t *testing.T) {

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -22,7 +22,6 @@ func newTestAgent(config *Config) *agent {
 		startTime: time.Now().UnixNano() / int64(time.Millisecond),
 		spanChan:  make(chan *spanChunk, cacheSize),
 		metaChan:  make(chan interface{}, cacheSize),
-		sampler:   newBasicTraceSampler(newRateSampler(1)),
 		config:    config,
 		objName: &objectName{
 			version:         nameV3,

--- a/noop.go
+++ b/noop.go
@@ -11,8 +11,12 @@ type noopAgent struct {
 	config *Config
 }
 
-var defaultNoopAgent = &noopAgent{
-	config: defaultConfig(),
+var defaultNoopAgent = &noopAgent{}
+
+// initNoopAgent must run after initConfig: defaultConfig reads cfgBaseMap, and
+// package variable initialization happens before any init function.
+func initNoopAgent() {
+	defaultNoopAgent.config = defaultConfig()
 }
 
 // NoopAgent returns a Agent that doesn't collect tracing data.
@@ -41,6 +45,7 @@ func (agent *noopAgent) Shutdown() {
 
 type noopSpan struct {
 	agent       *agent
+	cfg         *configSnapshot
 	spanId      int64
 	startTime   time.Time
 	rpcName     string
@@ -63,6 +68,7 @@ func NoopTracer() Tracer {
 func newUnSampledSpan(agent *agent, rpcName string) *noopSpan {
 	span := noopSpan{}
 	span.agent = agent
+	span.cfg = agent.config.load()
 	span.spanId = generateSpanId()
 	span.startTime = time.Now()
 	span.rpcName = rpcName
@@ -169,7 +175,7 @@ func (span *noopSpan) IsSampled() bool {
 }
 
 func (span *noopSpan) collectUrlStat(stat *UrlStatEntry) {
-	if span.withStats && span.agent.config.collectUrlStat {
+	if span.withStats && span.cfg.collectUrlStat {
 		if stat.Url == "" {
 			stat.Url = "UNKNOWN_URL"
 		}

--- a/plugin/http/config.go
+++ b/plugin/http/config.go
@@ -3,6 +3,7 @@ package pphttp
 import (
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/pinpoint-apm/pinpoint-go-agent"
 )
@@ -154,143 +155,123 @@ func WithHttpClientRecordRequestCookie(cookie []string) pinpoint.ConfigOption {
 	}
 }
 
+// httpConfig bundles every component derived from this plugin's options. A
+// reload rebuilds it whole and publishes it with a single atomic store, so a
+// request never sees a partially initialized filter or recorder.
+type httpConfig struct {
+	srvUrl             *httpUrlFilter
+	srvMethod          *httpMethodFilter
+	srvStatus          *httpStatusError
+	srvReqHeader       httpHeaderRecorder
+	srvResHeader       httpHeaderRecorder
+	srvCookie          httpHeaderRecorder
+	cltReqHeader       httpHeaderRecorder
+	cltResHeader       httpHeaderRecorder
+	cltCookie          httpHeaderRecorder
+	recordHandlerError bool
+}
+
+var httpConfigOpts = []string{
+	CfgHttpServerStatusCodeErrors,
+	CfgHttpServerExcludeUrl,
+	CfgHttpServerExcludeMethod,
+	CfgHttpServerRecordRequestHeader,
+	CfgHttpServerRecordResponseHeader,
+	CfgHttpServerRecordRequestCookie,
+	CfgHttpServerRecordHandlerError,
+	CfgHttpClientRecordRequestHeader,
+	CfgHttpClientRecordResponseHeader,
+	CfgHttpClientRecordRequestCookie,
+}
+
 var (
-	onceUrl sync.Once
-	srvUrl  *httpUrlFilter
+	onceHttpConfig sync.Once
+	curHttpConfig  atomic.Pointer[httpConfig]
 )
+
+// httpCfg returns the published config. The first call builds it - the agent
+// config does not exist yet at package init time - and registers the reload
+// callback that republishes it.
+//
+// ponytail: this store and the agent's config snapshot are two separate
+// publications, so a reload lands in two steps. Nothing couples them (each is
+// internally consistent on its own), and folding these into the agent snapshot
+// would mean either an import cycle or a map[string]any registry with a type
+// assertion on every request. Revisit if a derived value ever has to agree with
+// an agent option within the same generation.
+func httpCfg() *httpConfig {
+	onceHttpConfig.Do(func() {
+		curHttpConfig.Store(newHttpConfig())
+		pinpoint.GetConfig().AddReloadCallback(httpConfigOpts, func() {
+			curHttpConfig.Store(newHttpConfig())
+		})
+	})
+	return curHttpConfig.Load()
+}
+
+func newHttpConfig() *httpConfig {
+	return &httpConfig{
+		srvUrl:             newHttpUrlFilter(),
+		srvMethod:          newHttpExcludeMethod(),
+		srvStatus:          newHttpStatusError(),
+		srvReqHeader:       makeHttpHeaderRecorder(CfgHttpServerRecordRequestHeader),
+		srvResHeader:       makeHttpHeaderRecorder(CfgHttpServerRecordResponseHeader),
+		srvCookie:          makeHttpHeaderRecorder(CfgHttpServerRecordRequestCookie),
+		cltReqHeader:       makeHttpHeaderRecorder(CfgHttpClientRecordRequestHeader),
+		cltResHeader:       makeHttpHeaderRecorder(CfgHttpClientRecordResponseHeader),
+		cltCookie:          makeHttpHeaderRecorder(CfgHttpClientRecordRequestCookie),
+		recordHandlerError: pinpoint.GetConfig().Bool(CfgHttpServerRecordHandlerError),
+	}
+}
 
 func isExcludedUrl(url string) bool {
-	onceUrl.Do(func() {
-		initOptionExecutor(func() { srvUrl = newHttpUrlFilter() }, CfgHttpServerExcludeUrl)
-	})
-	return srvUrl.isFiltered(url)
+	return httpCfg().srvUrl.isFiltered(url)
 }
-
-var (
-	onceMethod sync.Once
-	srvMethod  *httpMethodFilter
-)
 
 func isExcludedMethod(method string) bool {
-	onceMethod.Do(func() {
-		initOptionExecutor(func() { srvMethod = newHttpExcludeMethod() }, CfgHttpServerExcludeMethod)
-	})
-	return srvMethod.isExcludedMethod(method)
+	return httpCfg().srvMethod.isExcludedMethod(method)
 }
 
-var (
-	onceStatus sync.Once
-	srvStatus  *httpStatusError
-)
-
 func recordServerHttpStatus(span pinpoint.SpanRecorder, status int) {
-	onceStatus.Do(func() {
-		initOptionExecutor(func() { srvStatus = newHttpStatusError() }, CfgHttpServerStatusCodeErrors)
-	})
-	if srvStatus.isError(status) {
+	if httpCfg().srvStatus.isError(status) {
 		span.SetFailure()
 	}
 	span.Annotations().AppendInt(pinpoint.AnnotationHttpStatusCode, int32(status))
 }
 
-var (
-	onceSrvReq   sync.Once
-	srvReqHeader httpHeaderRecorder
-)
-
 func recordServerHttpRequestHeader(annotation pinpoint.Annotation, header Header) {
-	onceSrvReq.Do(func() {
-		initOptionExecutor(
-			func() { srvReqHeader = makeHttpHeaderRecorder(CfgHttpServerRecordRequestHeader) },
-			CfgHttpServerRecordRequestHeader,
-		)
-	})
-	srvReqHeader.recordHeader(annotation, pinpoint.AnnotationHttpRequestHeader, header)
+	httpCfg().srvReqHeader.recordHeader(annotation, pinpoint.AnnotationHttpRequestHeader, header)
 }
-
-var (
-	onceSrvRes   sync.Once
-	srvResHeader httpHeaderRecorder
-)
 
 func recordServerHttpResponseHeader(annotation pinpoint.Annotation, header Header) {
-	onceSrvRes.Do(func() {
-		initOptionExecutor(
-			func() { srvResHeader = makeHttpHeaderRecorder(CfgHttpServerRecordResponseHeader) },
-			CfgHttpServerRecordResponseHeader,
-		)
-	})
-	srvResHeader.recordHeader(annotation, pinpoint.AnnotationHttpResponseHeader, header)
+	httpCfg().srvResHeader.recordHeader(annotation, pinpoint.AnnotationHttpResponseHeader, header)
 }
-
-var (
-	onceSrvCookie sync.Once
-	srvCookie     httpHeaderRecorder
-)
 
 func recordServerHttpCookie(annotation pinpoint.Annotation, cookie Cookie) {
-	onceSrvCookie.Do(func() {
-		initOptionExecutor(
-			func() { srvCookie = makeHttpHeaderRecorder(CfgHttpServerRecordRequestCookie) },
-			CfgHttpServerRecordRequestCookie,
-		)
-	})
-	srvCookie.recordCookie(annotation, cookie)
+	httpCfg().srvCookie.recordCookie(annotation, cookie)
 }
-
-var (
-	onceCltReq   sync.Once
-	cltReqHeader httpHeaderRecorder
-)
 
 func RecordClientHttpRequestHeader(annotation pinpoint.Annotation, header Header) {
-	onceCltReq.Do(func() {
-		initOptionExecutor(
-			func() { cltReqHeader = makeHttpHeaderRecorder(CfgHttpClientRecordRequestHeader) },
-			CfgHttpClientRecordRequestHeader,
-		)
-	})
-	cltReqHeader.recordHeader(annotation, pinpoint.AnnotationHttpRequestHeader, header)
+	httpCfg().cltReqHeader.recordHeader(annotation, pinpoint.AnnotationHttpRequestHeader, header)
 }
-
-var (
-	onceCltRes   sync.Once
-	cltResHeader httpHeaderRecorder
-)
 
 func RecordClientHttpResponseHeader(annotation pinpoint.Annotation, header Header) {
-	onceCltRes.Do(func() {
-		initOptionExecutor(
-			func() { cltResHeader = makeHttpHeaderRecorder(CfgHttpClientRecordResponseHeader) },
-			CfgHttpClientRecordResponseHeader,
-		)
-	})
-	cltResHeader.recordHeader(annotation, pinpoint.AnnotationHttpResponseHeader, header)
+	httpCfg().cltResHeader.recordHeader(annotation, pinpoint.AnnotationHttpResponseHeader, header)
 }
-
-var (
-	onceCltCookie sync.Once
-	cltCookie     httpHeaderRecorder
-)
 
 func RecordClientHttpCookie(annotation pinpoint.Annotation, cookie Cookie) {
-	onceCltCookie.Do(func() {
-		initOptionExecutor(
-			func() { cltCookie = makeHttpHeaderRecorder(CfgHttpClientRecordRequestCookie) },
-			CfgHttpClientRecordRequestCookie,
-		)
-	})
-	cltCookie.recordCookie(annotation, cookie)
+	httpCfg().cltCookie.recordCookie(annotation, cookie)
 }
 
-func initOptionExecutor(initFunc func(), opt string) {
-	initFunc()
-	pinpoint.GetConfig().AddReloadCallback([]string{opt}, initFunc)
+// RecordHttpHandlerError records error returned by http handler.
+func RecordHttpHandlerError(tracer pinpoint.Tracer, err error) {
+	if tracer.IsSampled() && httpCfg().recordHandlerError {
+		tracer.Span().SetError(err)
+	}
 }
 
 func makeHttpHeaderRecorder(cfgName string) httpHeaderRecorder {
-	cfg := pinpoint.GetConfig().StringSlice(cfgName)
-	trimStringSlice(cfg)
+	cfg := trimStringSlice(pinpoint.GetConfig().StringSlice(cfgName))
 
 	if len(cfg) == 0 {
 		return newNoopHttpHeaderRecorder()
@@ -301,27 +282,12 @@ func makeHttpHeaderRecorder(cfgName string) httpHeaderRecorder {
 	}
 }
 
-func trimStringSlice(slice []string) {
-	for i := range slice {
-		slice[i] = strings.TrimSpace(slice[i])
+// trimStringSlice returns a trimmed copy: the slice handed out by StringSlice
+// belongs to the published config snapshot and must not be written to.
+func trimStringSlice(slice []string) []string {
+	trimmed := make([]string, len(slice))
+	for i, s := range slice {
+		trimmed[i] = strings.TrimSpace(s)
 	}
-}
-
-var (
-	onceHandlerError   sync.Once
-	recordHandlerError bool
-)
-
-// RecordHttpHandlerError records error returned by http handler.
-func RecordHttpHandlerError(tracer pinpoint.Tracer, err error) {
-	onceHandlerError.Do(func() {
-		initOptionExecutor(
-			func() { recordHandlerError = pinpoint.GetConfig().Bool(CfgHttpServerRecordHandlerError) },
-			CfgHttpServerRecordHandlerError,
-		)
-	})
-	if tracer.IsSampled() && recordHandlerError {
-		span := tracer.Span()
-		span.SetError(err)
-	}
+	return trimmed
 }

--- a/plugin/http/config_race_test.go
+++ b/plugin/http/config_race_test.go
@@ -1,0 +1,74 @@
+package pphttp
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pinpoint-apm/pinpoint-go-agent"
+)
+
+// TestHttpConfigReloadRace republishes the plugin config concurrently with the
+// reads a request performs. Run it with -race: before the derived filters and
+// recorders were published as one immutable value, the reload callback
+// reassigned ten plain package globals that every request read.
+func TestHttpConfigReloadRace(t *testing.T) {
+	config, err := pinpoint.NewConfig(
+		pinpoint.WithAppName("raceApp"),
+		WithHttpServerExcludeUrl([]string{"/skip/*", "/**/*.do"}),
+		WithHttpServerExcludeMethod([]string{"put", "delete"}),
+		WithHttpServerStatusCodeError([]string{"5xx", "302"}),
+		WithHttpServerRecordRequestHeader([]string{"foo", "bar"}),
+		WithHttpServerRecordRespondHeader([]string{"HEADERS-ALL"}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pinpoint.NewTestAgent(config, t); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	stopped := func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // stands in for the config reload callback
+		defer wg.Done()
+		for !stopped() {
+			curHttpConfig.Store(newHttpConfig())
+		}
+	}()
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { // request goroutines
+			defer wg.Done()
+			for !stopped() {
+				_ = isExcludedUrl("/skip/index.html")
+				_ = isExcludedUrl("/keep/index.html")
+				_ = isExcludedMethod("PUT")
+				_ = isExcludedMethod("GET")
+
+				cfg := httpCfg()
+				_ = cfg.srvStatus.isError(500)
+				_ = cfg.recordHandlerError
+				if cfg.srvReqHeader == nil || cfg.srvResHeader == nil || cfg.cltCookie == nil {
+					t.Error("published http config has an uninitialized recorder")
+					return
+				}
+			}
+		}()
+	}
+
+	time.Sleep(300 * time.Millisecond)
+	close(done)
+	wg.Wait()
+}

--- a/plugin/http/status.go
+++ b/plugin/http/status.go
@@ -88,8 +88,7 @@ func newHttpStatusError() *httpStatusError {
 func setupHttpStatusErrors() []httpStatusCode {
 	var errors []httpStatusCode
 
-	cfgErrors := pinpoint.GetConfig().StringSlice(CfgHttpServerStatusCodeErrors)
-	trimStringSlice(cfgErrors)
+	cfgErrors := trimStringSlice(pinpoint.GetConfig().StringSlice(CfgHttpServerStatusCodeErrors))
 
 	for _, s := range cfgErrors {
 		if strings.EqualFold(s, "5xx") {

--- a/plugin/http/url.go
+++ b/plugin/http/url.go
@@ -181,8 +181,7 @@ func newHttpUrlFilter() *httpUrlFilter {
 func setupHttpUrlFilter() []*httpExcludeUrl {
 	var filters []*httpExcludeUrl
 
-	cfgFilters := pinpoint.GetConfig().StringSlice(CfgHttpServerExcludeUrl)
-	trimStringSlice(cfgFilters)
+	cfgFilters := trimStringSlice(pinpoint.GetConfig().StringSlice(CfgHttpServerExcludeUrl))
 
 	for _, u := range cfgFilters {
 		if u == "" {
@@ -211,8 +210,7 @@ type httpMethodFilter struct {
 }
 
 func newHttpExcludeMethod() *httpMethodFilter {
-	cfg := pinpoint.GetConfig().StringSlice(CfgHttpServerExcludeMethod)
-	trimStringSlice(cfg)
+	cfg := trimStringSlice(pinpoint.GetConfig().StringSlice(CfgHttpServerExcludeMethod))
 
 	return &httpMethodFilter{
 		excludeMethod: cfg,

--- a/plugin/pgxv5/pgxv5.go
+++ b/plugin/pgxv5/pgxv5.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sync"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/pinpoint-apm/pinpoint-go-agent"
@@ -18,33 +17,10 @@ var (
 	_ pgx.BatchTracer    = (*pgxTracer)(nil)
 	_ pgx.ConnectTracer  = (*pgxTracer)(nil)
 	_ pgx.CopyFromTracer = (*pgxTracer)(nil)
-
-	onceLoadConfig    sync.Once
-	gTraceBindValue   bool
-	gMaxBindValueSize int
 )
-
-func initTracerOptions(opt []string, initFunc func()) {
-	initFunc()
-	pinpoint.GetConfig().AddReloadCallback(opt, initFunc)
-}
 
 // NewTracer creates a tracer to instrument jackc/pgx calls.
 func NewTracer() *pgxTracer {
-	onceLoadConfig.Do(func() {
-		initTracerOptions(
-			[]string{
-				pinpoint.CfgSQLTraceBindValue,
-				pinpoint.CfgSQLMaxBindValueSize,
-			},
-			func() {
-				cfg := pinpoint.GetConfig()
-				gTraceBindValue = cfg.Bool(pinpoint.CfgSQLTraceBindValue)
-				gMaxBindValueSize = cfg.Int(pinpoint.CfgSQLMaxBindValueSize)
-			},
-		)
-	})
-
 	return &pgxTracer{}
 }
 
@@ -134,15 +110,17 @@ func newSpanEvent(ctx context.Context, config *pgx.ConnConfig, cmd string) pinpo
 }
 
 func (t *pgxTracer) composeArgs(args []any) string {
-	if args == nil || len(args) == 0 || !gTraceBindValue {
+	cfg := pinpoint.GetConfig()
+	if len(args) == 0 || !cfg.Bool(pinpoint.CfgSQLTraceBindValue) {
 		return ""
 	}
 
 	var b bytes.Buffer
 	numComma := len(args) - 1
+	maxSize := cfg.Int(pinpoint.CfgSQLMaxBindValueSize)
 
 	for i, v := range args {
-		if !writeArg(&b, i, v, numComma, gMaxBindValueSize) {
+		if !writeArg(&b, i, v, numComma, maxSize) {
 			break
 		}
 	}

--- a/span.go
+++ b/span.go
@@ -33,7 +33,10 @@ var (
 )
 
 type span struct {
-	agent              *agent
+	agent *agent
+	// cfg is pinned when the span is created and kept for its whole life, so a
+	// reload can never move this span's event limits mid-trace.
+	cfg                *configSnapshot
 	txId               TransactionId
 	spanId             int64
 	parentSpanId       int64
@@ -79,9 +82,14 @@ func generateSpanId() int64 {
 	return rand.Int63()
 }
 
-func defaultSpan() *span {
+// defaultSpan pins the agent's current config snapshot along with the agent
+// itself: the two always travel together, and the span keeps that snapshot for
+// its whole life.
+func defaultSpan(agent *agent) *span {
 	span := span{}
 
+	span.agent = agent
+	span.cfg = agent.config.load()
 	span.parentSpanId = -1
 	span.parentAppName = ""
 	span.parentAppType = 1 //UNKNOWN
@@ -99,9 +107,8 @@ func defaultSpan() *span {
 }
 
 func newSampledSpan(agent *agent, operation string, rpcName string) *span {
-	span := defaultSpan()
+	span := defaultSpan(agent)
 
-	span.agent = agent
 	span.operationName = operation
 	span.rpcName = rpcName
 	span.apiId = agent.cacheSpanApi(operation, apiTypeWebRequest)
@@ -354,9 +361,9 @@ func (span *span) newAsyncSpan() Tracer {
 		return NoopTracer()
 	}
 	if se, ok := span.eventStack.peek(); ok {
-		asyncSpan := defaultSpan()
+		asyncSpan := defaultSpan(span.agent)
 
-		asyncSpan.agent = span.agent
+		asyncSpan.cfg = span.cfg // an async span continues under its parent's snapshot
 		asyncSpan.txId = span.txId
 		asyncSpan.spanId = span.spanId
 
@@ -507,8 +514,8 @@ func (span *span) JsonString() []byte {
 	return b
 }
 
-func (span *span) config() *Config {
-	return span.agent.config
+func (span *span) config() *configSnapshot {
+	return span.cfg
 }
 
 func (span *span) canAddErrorChain() bool {

--- a/span_event.go
+++ b/span_event.go
@@ -157,6 +157,6 @@ func (se *spanEvent) agent() *agent {
 	return se.parentSpan.agent
 }
 
-func (se *spanEvent) config() *Config {
-	return se.agent().config
+func (se *spanEvent) config() *configSnapshot {
+	return se.parentSpan.cfg
 }

--- a/span_test.go
+++ b/span_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func Test_defaultSpan(t *testing.T) {
-	span := defaultSpan()
+	span := defaultSpan(newTestAgent(defaultConfig()))
 
 	assert.Equal(t, span.parentSpanId, int64(-1), "parentSpanId")
 	assert.Equal(t, span.parentAppType, 1, "parentAppType")
@@ -29,9 +29,14 @@ func (r *DistributedTracingContextMap) Set(key string, val string) {
 }
 
 func defaultTestSpan() *span {
-	span := defaultSpan()
-	span.agent = newTestAgent(defaultConfig())
-	return span
+	return testSpanWithConfig(defaultConfig())
+}
+
+// testSpanWithConfig pins the span to config, so callers that need non-default
+// limits must set them before the span is created - a live span keeps the
+// snapshot it was born with.
+func testSpanWithConfig(config *Config) *span {
+	return defaultSpan(newTestAgent(config))
 }
 
 func Test_span_Extract(t *testing.T) {
@@ -131,25 +136,32 @@ func Test_span_Inject_EventOverflow(t *testing.T) {
 	// Overflow limits profiling detail; it is not a sampling decision. The
 	// trace context must still be written or the downstream starts a new
 	// trace and the call chain is cut here.
+	// The limits are the smallest publishable ones: applyDynamicConfig clamps
+	// MaxCallStackDepth to minEventDepth and MaxCallStackSequence to
+	// minEventSequence, so the event counts below are what it takes to overflow.
 	tests := []struct {
 		name     string
+		limitOpt string
+		limit    int
 		overflow func(s *span)
 	}{
-		{"depth overflow - ancestor event left on the stack", func(s *span) {
-			s.agent.config.spanMaxEventDepth = 2
+		{"depth overflow - ancestor event left on the stack", CfgSpanMaxCallStackDepth, minEventDepth, func(s *span) {
 			s.NewSpanEvent("t1")
 			s.NewSpanEvent("t2")
 		}},
-		{"sequence overflow - empty stack", func(s *span) {
-			s.agent.config.spanMaxEventSequence = 1
-			s.NewSpanEvent("t1").EndSpanEvent()
+		{"sequence overflow - empty stack", CfgSpanMaxCallStackSequence, minEventSequence, func(s *span) {
+			for i := 0; i < minEventSequence; i++ {
+				s.NewSpanEvent("t1").EndSpanEvent()
+			}
 			s.NewSpanEvent("t2")
 		}},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			s := defaultTestSpan()
+			config := defaultConfig()
+			config.Set(tt.limitOpt, tt.limit)
+			s := testSpanWithConfig(config)
 			s.spanId = int64(12345)
 			s.txId = TransactionId{AgentId: "t123456", StartTime: int64(12345), Sequence: int64(1)}
 			tt.overflow(s)
@@ -211,9 +223,9 @@ func Test_span_NewSpanEventDepthOverflow(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			s := defaultTestSpan()
-			save := s.agent.config.spanMaxEventDepth
-			s.agent.config.spanMaxEventDepth = 3
+			config := defaultConfig()
+			config.Set(CfgSpanMaxCallStackDepth, 3)
+			s := testSpanWithConfig(config)
 
 			s.NewSpanEvent(tt.args.operationName)
 			s.NewSpanEvent(tt.args.operationName)
@@ -285,8 +297,6 @@ func Test_span_NewSpanEventDepthOverflow(t *testing.T) {
 			assert.Equal(t, s.eventStack.len(), 1, "stack.len()")
 			s.EndSpanEvent()
 			assert.Equal(t, s.eventStack.len(), 0, "stack.len()")
-
-			s.agent.config.spanMaxEventDepth = save
 		})
 	}
 }
@@ -305,9 +315,9 @@ func Test_span_NewSpanEventSequenceOverflow(t *testing.T) {
 	for _, tt := range tests {
 
 		t.Run(tt.name, func(t *testing.T) {
-			span := defaultTestSpan()
-			save := span.agent.config.spanMaxEventSequence
-			span.agent.config.spanMaxEventSequence = 5
+			config := defaultConfig()
+			config.Set(CfgSpanMaxCallStackSequence, 5)
+			span := testSpanWithConfig(config)
 
 			span.NewSpanEvent(tt.args.operationName).EndSpanEvent()
 			span.NewSpanEvent(tt.args.operationName).EndSpanEvent()
@@ -351,8 +361,6 @@ func Test_span_NewSpanEventSequenceOverflow(t *testing.T) {
 			assert.Equal(t, span.eventOverflow, 0, "eventOverflow")
 			assert.Equal(t, span.eventDepth, int32(1), "eventDepth")
 			assert.Equal(t, span.eventStack.len(), 0, "stack.len()")
-
-			span.agent.config.spanMaxEventSequence = save
 		})
 	}
 }

--- a/sql_driver.go
+++ b/sql_driver.go
@@ -174,14 +174,15 @@ func setSqlSpanEvent(tracer Tracer, start time.Time, err error, sql string, args
 }
 
 func (c *sqlConn) namedValueToString(named []driver.NamedValue) string {
-	if !c.config.sqlTraceBindValue || named == nil {
+	cfg := c.config.load()
+	if !cfg.sqlTraceBindValue || named == nil {
 		return ""
 	}
 
 	var b bytes.Buffer
 	numComma := len(named) - 1
 	for i, param := range named {
-		if !writeBindValue(&b, i, param.Value, numComma, c.config.sqlMaxBindValueSize) {
+		if !writeBindValue(&b, i, param.Value, numComma, cfg.sqlMaxBindValueSize) {
 			break
 		}
 	}
@@ -189,14 +190,15 @@ func (c *sqlConn) namedValueToString(named []driver.NamedValue) string {
 }
 
 func (c *sqlConn) valueToString(values []driver.Value) string {
-	if !c.config.sqlTraceBindValue || values == nil {
+	cfg := c.config.load()
+	if !cfg.sqlTraceBindValue || values == nil {
 		return ""
 	}
 
 	var b bytes.Buffer
 	numComma := len(values) - 1
 	for i, v := range values {
-		if !writeBindValue(&b, i, v, numComma, c.config.sqlMaxBindValueSize) {
+		if !writeBindValue(&b, i, v, numComma, cfg.sqlMaxBindValueSize) {
 			break
 		}
 	}
@@ -295,7 +297,7 @@ func (c *sqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx
 	start := time.Now()
 	if cbt, ok := c.Conn.(driver.ConnBeginTx); ok {
 		tx, err = cbt.BeginTx(ctx, opts)
-		if c.config.sqlTraceCommit || c.config.sqlTraceRollback {
+		if cfg := c.config.load(); cfg.sqlTraceCommit || cfg.sqlTraceRollback {
 			c.newSqlSpanEventNoSql(ctx, "BeginTx", start, err)
 			if err == nil {
 				tx = &sqlTx{tx, c, ctx}
@@ -305,7 +307,7 @@ func (c *sqlConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx
 	}
 
 	tx, err = c.Conn.Begin()
-	if c.config.sqlTraceCommit || c.config.sqlTraceRollback {
+	if cfg := c.config.load(); cfg.sqlTraceCommit || cfg.sqlTraceRollback {
 		c.newSqlSpanEventNoSql(ctx, "Begin", start, err)
 		if err == nil {
 			tx = &sqlTx{tx, c, ctx}
@@ -323,7 +325,7 @@ type sqlTx struct {
 func (t *sqlTx) Commit() (err error) {
 	start := time.Now()
 	err = t.Tx.Commit()
-	if t.conn.config.sqlTraceCommit {
+	if t.conn.config.load().sqlTraceCommit {
 		t.conn.newSqlSpanEventNoSql(t.ctx, "Commit", start, err)
 	}
 	return err
@@ -332,7 +334,7 @@ func (t *sqlTx) Commit() (err error) {
 func (t *sqlTx) Rollback() (err error) {
 	start := time.Now()
 	err = t.Tx.Rollback()
-	if t.conn.config.sqlTraceRollback {
+	if t.conn.config.load().sqlTraceRollback {
 		t.conn.newSqlSpanEventNoSql(t.ctx, "Rollback", start, err)
 	}
 	return err

--- a/url_stat.go
+++ b/url_stat.go
@@ -33,7 +33,7 @@ type urlStat struct {
 
 type urlStatSnapshot struct {
 	urlMap map[urlKey]*eachUrlStat
-	config *Config
+	config *configSnapshot
 	count  int
 }
 
@@ -62,7 +62,7 @@ type tickClock struct {
 func (agent *agent) newUrlStatSnapshot() *urlStatSnapshot {
 	return &urlStatSnapshot{
 		urlMap: make(map[urlKey]*eachUrlStat, 0),
-		config: agent.config,
+		config: agent.config.load(),
 	}
 }
 

--- a/url_stat_test.go
+++ b/url_stat_test.go
@@ -158,8 +158,7 @@ func Test_urlStatFailureUsesStatusFailureOnly(t *testing.T) {
 }
 
 func Test_spanStatusErrIsSetOnlyBySetFailure(t *testing.T) {
-	span := defaultSpan()
-	span.agent = newTestAgent(defaultConfig())
+	span := defaultSpan(newTestAgent(defaultConfig()))
 
 	span.SetError(errors.New("application error"))
 	assert.Equal(t, 1, span.err)
@@ -190,8 +189,8 @@ type expectedUrlHistogram struct {
 
 func newUrlStatTestSnapshot(limit int, withMethod bool) (*urlStatSnapshot, time.Time) {
 	config := defaultConfig()
-	config.urlStatLimitSize = limit
-	config.urlStatWithMethod = withMethod
+	config.Set(CfgHttpUrlStatLimitSize, limit)
+	config.Set(CfgHttpUrlStatWithMethod, withMethod)
 	agent := newTestAgent(config)
 	clock = newTickClock(urlStatCollectInterval)
 


### PR DESCRIPTION
## Summary

The config file watcher mutated live configuration in place while request
goroutines read it, with no synchronization: `applyDynamicConfig` assigned
`Config`'s typed fields, `setFinalValue` wrote `cfgMap[k].value` (an
`interface{}`), `newSampler` reassigned `agent.sampler`, and the reload
callbacks reassigned ten package globals in `plugin/http` and two in
`plugin/pgxv5`. `go test -race` reports 17 distinct races.

This replaces the in-place mutation with an immutable snapshot published by a
single atomic store, so an in-flight request can never observe a half-applied
reload — the same shape as the C++ agent's `AgentRuntime` generation swap.

Resolves #131.

## Changes

- **`configSnapshot` + `atomic.Pointer`.** Every reload-mutable value moves out
  of `Config` into an immutable `configSnapshot`: the option values plus the
  components derived from them, the sampler included. `applyDynamicConfig`
  becomes `publish()`, which normalizes and then installs the whole generation
  with one `Store`. `Config`'s identity is unchanged, since `GetConfig()` hands
  it out and `agent.config` / `sqlConn.config` / `logger.config` keep it for the
  process lifetime.

- **`cfgMap` demoted to staging.** It keeps the metadata and the build-time
  values; readers never touch it. A `sync.Mutex` guards it together with the
  reload callback list — which raced on its own, since the plugins append to it
  lazily on the first request while `reloadConfig` ranges over it on the watcher
  goroutine. Callbacks run off a copy with the lock released, so a callback may
  still register another.

- **Spans pin their snapshot.** An open span keeps the event limits it started
  with instead of re-reading them per event. `defaultSpan` now takes the agent
  so the agent and its snapshot are always set together; async spans inherit the
  parent's. `sqlConn` and the URL stat snapshot keep loading at use time, since
  those should track the current config.

- **`agent.sampler` folded into the snapshot,** so `newSampler` and its reload
  callback go away. The previous sampler is carried over when no sampling option
  changed, so an unrelated reload no longer resets the throughput limiter's
  counters (previously guaranteed by `isReloaded`).

- **`plugin/http`:** the ten globals (`srvUrl`, `srvMethod`, `srvStatus`, the
  six header/cookie recorders, `recordHandlerError`) collapse into one
  `atomic.Pointer[httpConfig]`, rebuilt whole in a single reload callback —
  ten `sync.Once` and ten callback registrations become one each. All the
  derived values are stateless, so rebuilding them together costs nothing.

- **`plugin/pgxv5`:** `gTraceBindValue` / `gMaxBindValueSize` and their reload
  callback are deleted; the options are read at use time, which is now a
  race-free snapshot read.

## Also fixed in the same path

`isReloaded` decided whether to fire a callback with `item.oldValue !=
item.value` on two `interface{}` values. When both hold `[]interface{}` — what
`viper.Get` returns for every `CfgStringSlice` option, i.e. all of
`plugin/http`'s — that comparison panics, on the watcher goroutine with no
recover:

```
panic: runtime error: comparing uncomparable type []interface {}
```

It survives on `main` only because the two operands usually have different
dynamic types (`[]string` default vs `[]interface{}` from the file). Both sides
hold `[]interface{}` as soon as the option is present in the config file at
startup and the file is edited once, or absent at startup and edited twice —
in either case after at least one request has registered the callback. Deciding
what changed now uses `reflect.DeepEqual`, and `Test_reloadConfig` covers it.

`trimStringSlice` also returned the slice it had written in place — the same
backing array `StringSlice()` had handed out from the config. It now returns a
copy, so the published snapshot stays immutable.

## Verification

```
go test -race ./...                     ok
cd plugin/http && go test -race ./...    ok
go vet ./...                             clean
```

All 33 plugin modules build.

New tests, both of which fail on `main`:

- `config_race_test.go` — `TestConfigReloadRace` drives `reloadConfig`
  concurrently with the accessors, span creation, span events, SQL bind value
  formatting and `AddReloadCallback`. 17 data races on `main` (3f11e52).
- `plugin/http/config_race_test.go` — `TestHttpConfigReloadRace` republishes the
  plugin config while requests read the filters and recorders. 1 data race
  against the pre-change globals.

Behaviour tests: `Test_reloadConfig` (values republished, callbacks fire only
for options the file actually changed, slice options do not panic) and
`Test_reloadConfig_keepsSamplerWhenSamplingUnchanged`.

## Note

One reload lands as two atomic stores — the agent snapshot, then
`plugin/http`'s — because the plugin is a separate module: folding its derived
filters into the agent snapshot would be an import cycle, and a
`map[string]any` registry would put a type assertion on every request. Nothing
couples the two (each is internally consistent on its own), so there is no
invariant to break. Flagged in a comment at the publication point in case a
derived value ever has to agree with an agent option within one generation.

`agent.enable` / `agent.shutdown` are a separate unsynchronized-flag defect and
are left to #123 / #126.
