### PR TITLE
[#137] Allow a full tps burst in the throughput sampler

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -109,11 +109,15 @@ func newThroughputLimitTraceSampler(base sampler, newTps int, continueTps int) *
 		contLimiter *rate.Limiter
 	)
 
+	// The burst is the tps itself, not 1: the Java and C++ agents refill a
+	// fixed window with tps tokens every second, so a burst of tps requests
+	// arriving at once is sampled in full. A burst of 1 would spread the same
+	// tps into one sample per 1/tps seconds and drop most of a bursty load.
 	if newTps > 0 {
-		newLimiter = rate.NewLimiter(per(newTps, time.Second), 1)
+		newLimiter = rate.NewLimiter(per(newTps, time.Second), newTps)
 	}
 	if continueTps > 0 {
-		contLimiter = rate.NewLimiter(per(continueTps, time.Second), 1)
+		contLimiter = rate.NewLimiter(per(continueTps, time.Second), continueTps)
 	}
 	return &throughputLimitTraceSampler{
 		baseSampler:           base,

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -1,6 +1,8 @@
 package pinpoint
 
 import (
+	"math"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -221,4 +223,51 @@ func Test_throughputLimitTraceSampler_skipContinue(t *testing.T) {
 			assert.Equal(t, int64(99*2), atomic.LoadInt64(&skipCont), "skipCont")
 		})
 	}
+}
+
+// countConcurrent fires n concurrent calls and returns how many were sampled.
+func countConcurrent(n int, isSampled func() bool) int {
+	var wg sync.WaitGroup
+	var count int64
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			if isSampled() {
+				atomic.AddInt64(&count, 1)
+			}
+		}()
+	}
+	wg.Wait()
+	return int(count)
+}
+
+func Test_throughputLimitTraceSampler_burst(t *testing.T) {
+	const tps = 100
+	s := newThroughputLimitTraceSampler(newRateSampler(1), tps, tps)
+
+	// a burst of tps requests arriving at once is sampled in full: the limiter
+	// starts with tps tokens, like the fixed window of the Java and C++ agents.
+	assert.Equal(t, tps, countConcurrent(tps, s.isNewSampled), "new burst")
+	assert.Equal(t, tps, countConcurrent(tps, s.isContinueSampled), "continue burst")
+
+	// the burst does not raise the average: the tokens are spent now, so a
+	// second of sustained load past the empty bucket yields about tps samples.
+	sampled := 0
+	for deadline := time.Now().Add(1 * time.Second); time.Now().Before(deadline); {
+		if s.isNewSampled() {
+			sampled++
+		}
+	}
+	assert.InDelta(t, tps, sampled, tps/10, "new average")
+}
+
+func Test_throughputLimitTraceSampler_hugeThroughput(t *testing.T) {
+	// a tps beyond one event per nanosecond makes per() an infinite rate: the
+	// burst of tps must neither overflow the limiter nor throttle anything.
+	s := newThroughputLimitTraceSampler(newRateSampler(1), math.MaxInt32, math.MaxInt32)
+
+	assert.Equal(t, 1000, countConcurrent(1000, s.isNewSampled), "new")
+	assert.Equal(t, 1000, countConcurrent(1000, s.isContinueSampled), "continue")
 }


### PR DESCRIPTION
## Summary

`newThroughputLimitTraceSampler` gave both `rate.Limiter`s a burst of 1, so the
bucket held a single token and never accumulated the allowance of an idle
period. `Sampling.NewThroughput: 100` meant one sample per 10ms rather than up
to 100 samples per second — of 100 requests arriving at the same instant, only
1 was sampled, so bursty traffic was sampled far below the configured tps.

Raising the burst to the tps itself makes `rate.Limiter` behave like the Guava
`SmoothBursty` limiter the Java agent uses: up to one second of tokens held,
still refilling at tps. The per-second average is unchanged; only the burst
tolerance is restored.

Resolves #137.

## Changes

- **`sampler.go`** — `rate.NewLimiter(per(tps, time.Second), tps)` for the new
  and the continue limiter both, instead of a burst of 1. A comment at the
  construction point records why the burst is the tps, since `1` reads like a
  deliberate serialization rather than an oversight.

## Testing

`go test -race ./...` passes.

Two new tests:

- `Test_throughputLimitTraceSampler_burst` — 100 concurrent calls at tps 100
  against `isNewSampled` and `isContinueSampled`, then a second of sustained
  load past the drained bucket. On `main` both burst assertions fail with 1 of
  100. The average assertion passes on `main` too, which is the point: the rate
  was never wrong, only the burst.
- `Test_throughputLimitTraceSampler_hugeThroughput` — `math.MaxInt32` for both
  limiters, 1000 concurrent calls each. A tps past one event per nanosecond
  truncates `per()` to `rate.Inf`, and `reserveN` short-circuits on an infinite
  limit before it consults the burst, so nothing throttles and nothing
  overflows. For every smaller tps the burst equals the rate, so the limiter's
  catch-up window is exactly one second.

The existing `Test_throughputLimitTraceSampler_skipNew` / `skipContinue` are
unaffected: they configure tps 1, where the burst is 1 either way.

## Note

This is a token bucket, not the C++ agent's fixed window, so it can spend up to
`2 * tps` across a window boundary. A fixed window admits the same `2 * tps`
across a boundary, so the ceiling is the same — and the token bucket is what
the Java agent already does.
