### PR TITLE
[#138] Flatten http status error config into a bit table

### DIFF
--- a/plugin/http/status.go
+++ b/plugin/http/status.go
@@ -1,123 +1,83 @@
 package pphttp
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/pinpoint-apm/pinpoint-go-agent"
 )
 
-type httpStatusCode interface {
-	isError(code int) bool
-}
+// statusTableSize is how many status codes the bit table covers. HTTP tops out
+// at the 5xx class, so every code a response can carry fits below it.
+const statusTableSize = 640 // 10 uint64 words
 
-type httpStatusInformational struct{}
-
-func newHttpStatusInformational() *httpStatusInformational {
-	return &httpStatusInformational{}
-}
-
-func (h *httpStatusInformational) isError(code int) bool {
-	return 100 <= code && code <= 199
-}
-
-type httpStatusSuccess struct{}
-
-func newHttpStatusSuccess() *httpStatusSuccess {
-	return &httpStatusSuccess{}
-}
-
-func (h *httpStatusSuccess) isError(code int) bool {
-	return 200 <= code && code <= 299
-}
-
-type httpStatusRedirection struct{}
-
-func newHttpStatusRedirection() *httpStatusRedirection {
-	return &httpStatusRedirection{}
-}
-
-func (h *httpStatusRedirection) isError(code int) bool {
-	return 300 <= code && code <= 399
-}
-
-type httpStatusClientError struct{}
-
-func newHttpStatusClientError() *httpStatusClientError {
-	return &httpStatusClientError{}
-}
-
-func (h *httpStatusClientError) isError(code int) bool {
-	return 400 <= code && code <= 499
-}
-
-type httpStatusServerError struct{}
-
-func newHttpStatusServerError() *httpStatusServerError {
-	return &httpStatusServerError{}
-}
-
-func (h *httpStatusServerError) isError(code int) bool {
-	return 500 <= code && code <= 599
-}
-
-type httpStatusDefault struct {
-	statusCode int
-}
-
-func newHttpStatusDefault(code int) *httpStatusDefault {
-	return &httpStatusDefault{
-		statusCode: code,
-	}
-}
-
-func (h *httpStatusDefault) isError(code int) bool {
-	return h.statusCode == code
-}
-
+// httpStatusError decides whether a response status counts as a failure.
+//
+// The configured tokens are flattened into a bit table once, when the config is
+// parsed, so a request pays a bounds check and one bit lookup instead of an
+// interface call per configured entry.
 type httpStatusError struct {
-	errors []httpStatusCode
+	codes [statusTableSize / 64]uint64
+
+	// Codes the table cannot hold: a number outside it, or a token that does
+	// not parse - which the old per-token matcher kept as -1 and compared
+	// against the status. No net/http response carries one, but the exported
+	// RecordHttpServerResponse takes any int, so they are kept rather than
+	// dropped, and the verdict stays what it was for every input.
+	outOfTable []int
 }
 
 func newHttpStatusError() *httpStatusError {
-	return &httpStatusError{
-		errors: setupHttpStatusErrors(),
-	}
+	return parseHttpStatusErrors(pinpoint.GetConfig().StringSlice(CfgHttpServerStatusCodeErrors))
 }
 
-func setupHttpStatusErrors() []httpStatusCode {
-	var errors []httpStatusCode
+// parseHttpStatusErrors expands the configured tokens - a status class, "1xx"
+// through "5xx" case-insensitively, or a single status code - into the table.
+func parseHttpStatusErrors(cfg []string) *httpStatusError {
+	h := &httpStatusError{}
 
-	cfgErrors := trimStringSlice(pinpoint.GetConfig().StringSlice(CfgHttpServerStatusCodeErrors))
-
-	for _, s := range cfgErrors {
-		if strings.EqualFold(s, "5xx") {
-			errors = append(errors, newHttpStatusServerError())
-		} else if strings.EqualFold(s, "4xx") {
-			errors = append(errors, newHttpStatusClientError())
-		} else if strings.EqualFold(s, "3xx") {
-			errors = append(errors, newHttpStatusRedirection())
-		} else if strings.EqualFold(s, "2xx") {
-			errors = append(errors, newHttpStatusSuccess())
-		} else if strings.EqualFold(s, "1xx") {
-			errors = append(errors, newHttpStatusInformational())
-		} else {
-			c, e := strconv.Atoi(s)
-			if e != nil {
+	for _, s := range trimStringSlice(cfg) {
+		switch {
+		case strings.EqualFold(s, "1xx"):
+			h.setRange(100, 199)
+		case strings.EqualFold(s, "2xx"):
+			h.setRange(200, 299)
+		case strings.EqualFold(s, "3xx"):
+			h.setRange(300, 399)
+		case strings.EqualFold(s, "4xx"):
+			h.setRange(400, 499)
+		case strings.EqualFold(s, "5xx"):
+			h.setRange(500, 599)
+		default:
+			c, err := strconv.Atoi(s)
+			if err != nil {
 				c = -1
 			}
-			errors = append(errors, newHttpStatusDefault(c))
+			h.set(c)
 		}
 	}
 
-	return errors
+	return h
+}
+
+func (h *httpStatusError) setRange(min, max int) {
+	for code := min; code <= max; code++ {
+		h.set(code)
+	}
+}
+
+func (h *httpStatusError) set(code int) {
+	if uint(code) < statusTableSize {
+		h.codes[code/64] |= 1 << (uint(code) % 64)
+	} else {
+		h.outOfTable = append(h.outOfTable, code)
+	}
 }
 
 func (h *httpStatusError) isError(code int) bool {
-	for _, h := range h.errors {
-		if h.isError(code) {
-			return true
-		}
+	if uint(code) < statusTableSize {
+		return h.codes[code/64]&(1<<(uint(code)%64)) != 0
 	}
-	return false
+	return slices.Contains(h.outOfTable, code)
 }

--- a/plugin/http/status_test.go
+++ b/plugin/http/status_test.go
@@ -1,0 +1,190 @@
+package pphttp
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The pre-bitmap implementation, kept verbatim as the oracle the bit table is
+// compared against and as the "before" side of the benchmark. It walked a slice
+// of interface values and made one dynamic call per configured entry.
+
+type legacyStatusCode interface {
+	isError(code int) bool
+}
+
+type legacyStatusInformational struct{}
+
+func (h *legacyStatusInformational) isError(code int) bool { return 100 <= code && code <= 199 }
+
+type legacyStatusSuccess struct{}
+
+func (h *legacyStatusSuccess) isError(code int) bool { return 200 <= code && code <= 299 }
+
+type legacyStatusRedirection struct{}
+
+func (h *legacyStatusRedirection) isError(code int) bool { return 300 <= code && code <= 399 }
+
+type legacyStatusClientError struct{}
+
+func (h *legacyStatusClientError) isError(code int) bool { return 400 <= code && code <= 499 }
+
+type legacyStatusServerError struct{}
+
+func (h *legacyStatusServerError) isError(code int) bool { return 500 <= code && code <= 599 }
+
+type legacyStatusDefault struct{ statusCode int }
+
+func (h *legacyStatusDefault) isError(code int) bool { return h.statusCode == code }
+
+type legacyStatusError struct {
+	errors []legacyStatusCode
+}
+
+func newLegacyStatusError(cfg []string) *legacyStatusError {
+	var errors []legacyStatusCode
+
+	for _, s := range trimStringSlice(cfg) {
+		if strings.EqualFold(s, "5xx") {
+			errors = append(errors, &legacyStatusServerError{})
+		} else if strings.EqualFold(s, "4xx") {
+			errors = append(errors, &legacyStatusClientError{})
+		} else if strings.EqualFold(s, "3xx") {
+			errors = append(errors, &legacyStatusRedirection{})
+		} else if strings.EqualFold(s, "2xx") {
+			errors = append(errors, &legacyStatusSuccess{})
+		} else if strings.EqualFold(s, "1xx") {
+			errors = append(errors, &legacyStatusInformational{})
+		} else {
+			c, e := strconv.Atoi(s)
+			if e != nil {
+				c = -1
+			}
+			errors = append(errors, &legacyStatusDefault{statusCode: c})
+		}
+	}
+
+	return &legacyStatusError{errors: errors}
+}
+
+func (h *legacyStatusError) isError(code int) bool {
+	for _, h := range h.errors {
+		if h.isError(code) {
+			return true
+		}
+	}
+	return false
+}
+
+// statusTokenSets covers every token shape the parser accepts, plus the ones it
+// rejects: a status class in either case, single codes, codes on and past the
+// edge of the bit table, duplicates, whitespace, and garbage.
+var statusTokenSets = [][]string{
+	nil,
+	{},
+	{"5xx"},
+	{"5XX"},
+	{"5Xx"},
+	{"4xx"},
+	{"3xx"},
+	{"2xx"},
+	{"1xx"},
+	{"1xx", "2xx", "3xx", "4xx", "5xx"},
+	{"4xx", "5xx"},
+	{"4Xx", "3xX"},
+	{"404"},
+	{"404", "500", "503"},
+	{"5xx", "302", "404"},
+	{"  501  ", "\t404"},
+	{"404", "404", "4xx"},
+	{"0"},
+	{"99"},
+	{"100"},
+	{"599"},
+	{"600"},
+	{"639"},
+	{"640"},
+	{"641"},
+	{"999"},
+	{"1000"},
+	{"+404"},
+	{"-1"},
+	{"-404"},
+	{"0404"},
+	{""},
+	{"abc"},
+	{"6xx"},
+	{"0xx"},
+	{"xx"},
+	{"5x"},
+	{"5xxx"},
+	{"x5x"},
+	{"40 4"},
+	{"404.0"},
+	{"99999999999999999999"},
+	{"5xx", "abc", "", "1000", "-7"},
+}
+
+// TestHttpStatusErrorMatchesLegacy is the equivalence check: for every token set
+// the bit table must return exactly what the interface slice returned. The range
+// runs past 0-599 on both sides so the table edge, negatives and codes the
+// exported RecordHttpServerResponse could still be handed are covered too.
+func TestHttpStatusErrorMatchesLegacy(t *testing.T) {
+	for _, tokens := range statusTokenSets {
+		t.Run(strings.Join(tokens, ","), func(t *testing.T) {
+			legacy := newLegacyStatusError(tokens)
+			bitmap := parseHttpStatusErrors(tokens)
+
+			for code := -1100; code <= 1100; code++ {
+				if want, got := legacy.isError(code), bitmap.isError(code); want != got {
+					t.Fatalf("isError(%d) = %v, want %v (tokens %q)", code, got, want, tokens)
+				}
+			}
+		})
+	}
+}
+
+var (
+	statusBenchCodes = []int{200, 201, 204, 301, 302, 400, 404, 500, 503}
+	statusBenchSink  bool
+
+	statusBenchConfigs = []struct {
+		name string
+		cfg  []string
+	}{
+		{"1entry", []string{"5xx"}},
+		{"2entries", []string{"5xx", "404"}},
+		{"8entries", []string{"1xx", "2xx", "3xx", "4xx", "5xx", "404", "500", "503"}},
+	}
+)
+
+func BenchmarkHttpStatusErrorLegacy(b *testing.B) {
+	for _, c := range statusBenchConfigs {
+		h := newLegacyStatusError(c.cfg)
+		b.Run(c.name, func(b *testing.B) {
+			var hit bool
+			for i := 0; i < b.N; i++ {
+				for _, code := range statusBenchCodes {
+					hit = h.isError(code)
+				}
+			}
+			statusBenchSink = hit
+		})
+	}
+}
+
+func BenchmarkHttpStatusErrorBitmap(b *testing.B) {
+	for _, c := range statusBenchConfigs {
+		h := parseHttpStatusErrors(c.cfg)
+		b.Run(c.name, func(b *testing.B) {
+			var hit bool
+			for i := 0; i < b.N; i++ {
+				for _, code := range statusBenchCodes {
+					hit = h.isError(code)
+				}
+			}
+			statusBenchSink = hit
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`Http.Server.StatusCodeErrors` was evaluated by walking a slice of interface
values on every sampled server response. `setupHttpStatusErrors` built one
matcher object per configured token and `isError` made a dynamic call per
element until one returned true, so the check cost grew with the number of
configured entries — an operator who lists `1xx`..`5xx` plus a few individual
codes paid for all of them on a response that matched nothing.

The tokens are a closed domain (a status class, or a single code) and are fully
known once the config is parsed. This expands them into a bit table at parse
time and reduces the request path to a bounds check and one bit lookup — the
same shape as the C++ agent's `HttpStatusErrors` and its `std::bitset<600>`.

Resolves #138.

## Changes

- **`httpStatusError` holds a `[10]uint64` table** covering codes 0-639. The
  `httpStatusCode` interface and all six implementations
  (`httpStatusInformational` through `httpStatusDefault`) are deleted; net 97
  lines of `status.go` removed for 57.

- **Parsing splits from config reading.** `newHttpStatusError()` still reads the
  option, `parseHttpStatusErrors(cfg []string)` does the work, which is what
  lets the test drive tokens directly. Class tokens stay `strings.EqualFold`
  compares and `trimStringSlice` still runs first, so the token grammar is
  untouched.

- **`outOfTable` keeps two edge behaviours exact.** A token that does not parse
  fell through to `strconv.Atoi` and was stored as `newHttpStatusDefault(-1)` —
  so `["abc"]` is a rule matching status `-1` today, not an empty rule set. And
  `Atoi` accepts any `int64`, so `["1000"]` is a live rule. Neither is reachable
  through `net/http`, but `RecordHttpServerResponse` is exported and takes the
  status from whatever framework plugin calls it, so both are kept in a slice
  the request path reaches only for a code outside the table. It is empty for
  every real configuration.

  This is the one place the behaviour deliberately differs from C++, which warns
  and drops out-of-range tokens. Matching that would change the verdict.

The table is built once per config generation, inside the `httpConfig` rebuild
added in #132 — no new publication point.

## Benchmark

Request path only, both implementations benched in the same binary; the "before"
side is the previous code carried into the test file verbatim. Each op is nine
status codes. `benchstat`, `-count 10`, Apple M1 Pro, go1.24.7 darwin/arm64.

| configured entries | before | after | change |
|---|---|---|---|
| 1 — `5xx` | 21.49n ± 4% | 8.41n ± 19% | **-60.88%** |
| 2 — `5xx,404` | 34.95n ± 2% | 8.35n ± 25% | **-76.11%** |
| 8 — `1xx`..`5xx`,`404`,`500`,`503` | 71.44n ± 5% | 8.24n ± 18% | **-88.47%** |
| geomean | 37.71n | 8.33n | **-77.91%** |

`p=0.000 (n=10)` on all three; zero allocations on both sides.

The absolute numbers are small — the point is the slope. The previous cost grew
with the number of configured entries (21n → 35n → 71n); the table is flat at
~8.3n regardless.

## Testing

`plugin/http/status_test.go` keeps the previous implementation verbatim as
`legacyStatusError` and uses it as both the oracle and the "before" benchmark.

`TestHttpStatusErrorMatchesLegacy` compares the two over **43 token sets ×
codes -1100..1100**: class tokens in mixed case, single codes, whitespace,
duplicates, the table edge (`599`/`600`/`639`/`640`/`641`), negatives, `+404`,
`0404`, the empty string, `abc`, near-misses (`6xx`, `0xx`, `5x`, `5xxx`,
`x5x`), `404.0`, an `int64` overflow (`99999999999999999999`), and mixtures.

`go test -race ./...` is green in the root module and in `plugin/http`.
`plugin/http/example` still fails to build on `main` for an unrelated reason
(two `func main` in one directory, `http_mux.go:36` and `http_server.go:59`);
that directory is untouched here.
