### PR TITLE
[#141] Pad activeSpanRegistry shards to a cache line

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -11,14 +11,16 @@ package pinpoint
 //	go test -run=^$ -bench=. -benchmem
 //	go test -run=^$ -bench=Parallel -benchmem -cpu=1,4,8   // scalability under contention
 //
-// The parallel variants are the important ones for shared-state contention:
-// the apiCache lru lock (cacheSpanApi) and the activeSpan sync.Map are taken on
-// every span event / span, so their cost only shows up across multiple cores.
+// The parallel variants are the important ones for shared-state contention: the
+// apiCache lru lock (cacheSpanApi) is taken on every span event and an
+// active-span registry shard lock on every span, so their cost only shows up
+// across multiple cores.
 
 import (
 	"errors"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -154,7 +156,9 @@ func BenchmarkSpanEventParallel(b *testing.B) {
 
 // BenchmarkSpanLifecycle measures a full transaction end to end: span creation,
 // a few span events, and EndSpan. Beyond the event path this also covers the
-// activeSpan sync.Map store/delete and the response-time atomics.
+// sharded active-span registry store/remove, the real-time active-span sync.Map
+// delete EndSpan runs whether or not a stream is active, and the response-time
+// atomics.
 func BenchmarkSpanLifecycle(b *testing.B) {
 	a := benchAgent()
 	stop := startDrain(a)
@@ -172,7 +176,8 @@ func BenchmarkSpanLifecycle(b *testing.B) {
 }
 
 // BenchmarkSpanLifecycleParallel measures the full transaction path under
-// contention: activeSpan sync.Map churn and apiCache lru lock across cores.
+// contention: active-span registry shard churn and the apiCache lru lock across
+// cores.
 func BenchmarkSpanLifecycleParallel(b *testing.B) {
 	a := benchAgent()
 	stop := startDrain(a)
@@ -191,9 +196,43 @@ func BenchmarkSpanLifecycleParallel(b *testing.B) {
 	})
 }
 
+// BenchmarkActiveSpanRegistryParallel measures the in-flight span registry the
+// way requests hit it: every goroutine registers a span and immediately
+// unregisters it, walking its own span-id range so the goroutines land on
+// different shards the way random span ids spread them in production.
+//
+// Run with -cpu=1,4,16. The -cpu=1 number is the uncontended store/delete cost;
+// what the higher counts add on top is shard contention, which is both the lock
+// itself and any cache line two shards happen to share.
+func BenchmarkActiveSpanRegistryParallel(b *testing.B) {
+	const residentPerShard = 8
+
+	r := newActiveSpanRegistry()
+	start := time.Now()
+	// Keep a working set registered so the measured store/delete hits populated
+	// map buckets instead of a degenerate empty map.
+	for i := 0; i < activeSpanShardCount*residentPerShard; i++ {
+		r.store(int64(i), start)
+	}
+
+	var idBase int64
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		// A private id range per goroutine, incremented every iteration: no two
+		// goroutines contend on the same key, and consecutive ids sweep all shards.
+		id := atomic.AddInt64(&idBase, 1<<32)
+		for pb.Next() {
+			r.store(id, start)
+			r.remove(id)
+			id++
+		}
+	})
+}
+
 // BenchmarkExtractContinue isolates distributed-tracing header parsing on the
 // continue-trace path (TraceID present): trace-id parsing + ParseInt + the
-// activeSpan sync.Map store. The span is allocated once so the measurement
+// active-span registry store. The span is allocated once so the measurement
 // reflects Extract itself, not span creation (covered by BenchmarkNewSampledSpan).
 func BenchmarkExtractContinue(b *testing.B) {
 	a := benchAgent()

--- a/stats.go
+++ b/stats.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/shirou/gopsutil/v3/cpu"
 	"github.com/shirou/gopsutil/v3/process"
@@ -65,9 +66,27 @@ type activeSpanRegistry struct {
 	shards [activeSpanShardCount]activeSpanShard
 }
 
-type activeSpanShard struct {
+// cacheLinePadSize is the stride the shards are spaced at. 128 and not 64:
+// arm64 uses 128-byte lines (hw.cachelinesize is 128 on Apple silicon) and x86
+// prefetches adjacent line pairs, and since Go aligns a heap struct to only 8
+// bytes the extra slack also absorbs the shard array starting mid-line. Same
+// constant sync.Pool pads poolLocal with, for the same reason.
+const cacheLinePadSize = 128
+
+type activeSpanShardInternal struct {
 	mu sync.Mutex
 	m  map[int64]time.Time
+}
+
+// activeSpanShard gives every shard its own cache line. The payload is 16 bytes
+// (unsafe.Sizeof: an 8-byte sync.Mutex plus an 8-byte map header), so unpadded
+// eight shards share one line and two goroutines locking *different* shards
+// still ping-pong it -- worth -35% per op at -cpu=16, see
+// BenchmarkActiveSpanRegistryParallel. Deriving the pad from unsafe.Sizeof
+// rather than hardcoding 112 keeps it correct if a field is added.
+type activeSpanShard struct {
+	activeSpanShardInternal
+	_ [cacheLinePadSize - unsafe.Sizeof(activeSpanShardInternal{})%cacheLinePadSize]byte
 }
 
 func newActiveSpanRegistry() *activeSpanRegistry {

--- a/stats_test.go
+++ b/stats_test.go
@@ -3,6 +3,7 @@ package pinpoint
 import (
 	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -59,4 +60,12 @@ func Test_collectResponseTimePreservesMax(t *testing.T) {
 
 func Test_calcResponseAvgReturnsZeroWithoutRequests(t *testing.T) {
 	assert.Equal(t, int64(0), calcResponseAvg(100, 0))
+}
+
+// Test_activeSpanShardIsCacheLinePadded guards the false-sharing fix: the shards
+// must stay a whole cache line apart, not packed several to a line.
+func Test_activeSpanShardIsCacheLinePadded(t *testing.T) {
+	if got := unsafe.Sizeof(activeSpanShard{}); got%cacheLinePadSize != 0 {
+		t.Errorf("activeSpanShard is %d bytes, not a multiple of the %d-byte shard stride: shards share a cache line", got, cacheLinePadSize)
+	}
 }


### PR DESCRIPTION
## Summary

`activeSpanRegistry` shards the in-flight span map 32 ways to keep `store`/`remove`
off a single lock, but nothing spaced the shards out. The payload is 16 bytes
(an 8-byte `sync.Mutex` plus an 8-byte map header), so the array was 512 bytes
and packed four shards into every 64-byte cache line — eight into the 128-byte
line arm64 uses.

Every sampled and unsampled span touches a shard twice, `store` at span start and
`remove` at `EndSpan`, and the shard comes from the random span id. So the case
the sharding was meant to make cheap — concurrent requests spread uniformly over
the shards — is the case that collides on a shared line. The locks do not
conflict; the coherence traffic does, since every `Lock`/`Unlock` writes the line
and invalidates it for every core holding a neighbouring shard.

This gives each shard its own line, the same thing the C++ agent's
`alignas(64) ActiveSpanShard` (`src/active_span.h`) does. The data structure and
the shard count are unchanged.

Resolves #141.

## Changes

- **`activeSpanShard` splits into a padded wrapper over
  `activeSpanShardInternal`**, the pattern the standard library uses for
  `sync.Pool`'s `poolLocal`. Embedding leaves every `s.mu` and `s.m` use site
  untouched, and deriving the pad from `unsafe.Sizeof` rather than hardcoding
  112 keeps it correct if a field is ever added to the shard.

- **The stride is 128, not the C++ `alignas(64)`.** This is the one place the fix
  has to differ: C++ gets a real alignment guarantee from the language, Go does
  not. The registry is heap allocated, so its base is only 8-byte aligned — it
  was observed starting 88 bytes into a line. A 64-byte stride still lands two
  shards on one 128-byte hardware line; 128 absorbs any 8-byte-granular start
  offset, and each shard's `mu` and `m` were confirmed to sit alone on their own
  line. It also measured a further -4.46% (`p=0.045`) over 64 at `-cpu=16`.

  The registry grows from 512 B to 4 KB, allocated once at agent init.

- **`BenchmarkActiveSpanRegistryParallel`** — added *first*, to establish the
  baseline before the change. Each goroutine registers and unregisters over its
  own span-id range, so no two contend on the same key and consecutive ids sweep
  every shard, the spread random span ids produce. A resident working set of 8
  spans per shard keeps `store`/`remove` on populated map buckets instead of a
  degenerate empty map.

- **A layout guard test** asserts the shard stays a whole multiple of the stride,
  so removing the pad fails the suite rather than silently regressing.

- **Four stale benchmark comments corrected.** They still described the registry
  as a `sync.Map`, which it stopped being when the sharded map replaced it — and
  one of them sits directly beside the benchmark added here, so the file
  described the same structure two ways. Note that the real-time active-span
  view in `command.go` *is* still a genuine `sync.Map` and `EndSpan` deletes from
  it whether or not a command stream is active, so the lifecycle comment names
  both instead of dropping the `sync.Map` mention. Comment-only; no code moved.

## Benchmark

`benchstat`, `-cpu=1,4,16`, Apple M1 Pro (`hw.cachelinesize` 128), go1.24.7
darwin/arm64. Zero allocations on every variant.

The variants were built as **separate test binaries and run interleaved for 12
rounds**. This matters: a first, non-interleaved attempt read as "no improvement"
and was wrong — sequential runs drift enough on this machine to invent a result.

| `-cpu` | unpadded | stride 64 | stride 128 | 128 vs unpadded |
|---|---|---|---|---|
| 1 | 34.16n ± 1% | 34.52n ± 3% | 34.50n ± 2% | **+1.00%** (p=0.037) |
| 4 | 49.86n ± 20% | 38.20n ± 34% | 36.55n ± 19% | **-26.68%** (p=0.000) |
| 16 | 112.75n ± 5% | 76.20n ± 5% | 72.80n ± 3% | **-35.43%** (p=0.000) |
| geomean | 57.69n | 46.49n | 45.11n | **-21.80%** |

The `+1.00%` at `-cpu=1` is a real cost, not noise (`p=0.037`): one goroutine
sweeping all 32 shards now touches 4 KB instead of 512 B. It is repaid as soon as
a second core participates.

End to end through the full span path (`BenchmarkSpanLifecycleParallel`, 8
interleaved rounds), `-cpu=16`: 1.095 µs → 1.076 µs, **-1.74%** (`p=0.035`). A
span lifecycle is ~1.1 µs and contains one `store`/`remove` pair, so a ~40 ns
saving landing as ~2% is the expected ratio.

## Testing

`go test -race ./...` is green. `go vet` and `gofmt` clean on the three touched
files.

`Test_activeSpanShardIsCacheLinePadded` fails if the pad is dropped — verified by
building the unpadded variant against the new test file, which does not compile
once the constant is gone.

The C++ agent was read for reference only and is not touched.
