### PR TITLE
[#143] Make reconnect back-off cancellable and align its parameters

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -56,6 +56,14 @@ type agent struct {
 	enable    atomic.Bool
 	shutdown  atomic.Bool
 
+	// stopCtx is cancelled when shutdown begins. The shutdown flag above is
+	// only polled, so it cannot wake a goroutine already blocked in a
+	// reconnect wait; the context can. Created lazily because the agent is
+	// built as a struct literal in several places, including test helpers.
+	stopOnce   sync.Once
+	stopCtx    context.Context
+	stopCancel context.CancelFunc
+
 	// grpcMetaCtx caches the outgoing-metadata context (socketId <= 0), whose
 	// headers are immutable for the agent's lifetime, so per-send callers reuse
 	// it instead of rebuilding the metadata map on every request.
@@ -242,6 +250,24 @@ func (agent *agent) connectGrpcServer() {
 	go agent.sendStatsWorker()
 }
 
+// stopSignal returns a context cancelled when shutdown begins. Reconnect waits
+// derive their deadline from it, so a shutdown aborts them instead of holding
+// the agent for a whole back-off interval.
+func (agent *agent) stopSignal() context.Context {
+	agent.stopOnce.Do(func() {
+		agent.stopCtx, agent.stopCancel = context.WithCancel(context.Background())
+	})
+	return agent.stopCtx
+}
+
+// signalShutdown marks the agent as shutting down and unblocks the waits that
+// are already in progress.
+func (agent *agent) signalShutdown() {
+	agent.shutdown.Store(true)
+	agent.stopSignal() // ensure the context exists before cancelling it
+	agent.stopCancel()
+}
+
 // waitTimeout waits for wg and reports whether it completed within timeout.
 func waitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 	done := make(chan struct{})
@@ -267,7 +293,7 @@ func (agent *agent) Shutdown() {
 	// the normal shutdown path pays nothing here.
 	waitTimeout(&agent.connectWg, connectGraceTimeout)
 
-	agent.shutdown.Store(true)
+	agent.signalShutdown()
 	Log("agent").Infof("shutdown pinpoint agent")
 
 	// wait for the grpc connection to be completed

--- a/grpc.go
+++ b/grpc.go
@@ -81,16 +81,27 @@ func (agent *agent) baseOutgoingContext() context.Context {
 	return agent.grpcMetaCtx
 }
 
-func backOffSleep(attempt int) time.Duration {
-	base := float64(1 * time.Second)
-	max := float64(60 * time.Second)
+const (
+	// Reconnect back-off, matching the C++ agent's GrpcClientTuning: a gentle
+	// x1.2 ramp from 3s to a 30s ceiling, randomized +/-30%.
+	backOffInitialInterval = 3 * time.Second
+	backOffMultiplier      = 1.2
+	backOffMaxInterval     = 30 * time.Second
+	backOffJitter          = 0.3
+)
 
-	dur := base * math.Pow(2, float64(attempt))
-	if dur > max {
-		dur = max
+// backOffSleep returns how long to wait before reconnect attempt+1, with the
+// first attempt numbered 0.
+func backOffSleep(attempt int) time.Duration {
+	dur := float64(backOffInitialInterval) * math.Pow(backOffMultiplier, float64(attempt))
+	if dur > float64(backOffMaxInterval) {
+		dur = float64(backOffMaxInterval)
 	}
 
-	return time.Duration(rand.Float64()*(dur-base) + base)
+	// Randomize so agents restarted together do not reconnect in lockstep. The
+	// jitter is applied after the clamp, as in the C++ agent, so a capped
+	// interval lands within +/-30% of the ceiling rather than always on it.
+	return time.Duration(dur * (1 - backOffJitter + rand.Float64()*2*backOffJitter))
 }
 
 type agentClient interface {
@@ -303,11 +314,7 @@ func (agentGrpc *agentGrpc) registerAgentWithRetry() bool {
 			}
 		}
 
-		for retry := 1; !agentGrpc.agent.shutdown.Load(); retry++ {
-			if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-				break
-			}
-		}
+		backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		if agentInfo.Ip == "" {
 			agentInfo.Ip = getOutboundIP()
 		}
@@ -352,11 +359,7 @@ func (agentGrpc *agentGrpc) sendApiMetadataWithRetry(apiId int32, api string, li
 		}
 
 		if !agentGrpc.agent.config.offGrpc {
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		}
 	}
 	return false
@@ -391,11 +394,7 @@ func (agentGrpc *agentGrpc) sendStringMetadataWithRetry(strId int32, str string)
 		}
 
 		if !agentGrpc.agent.config.offGrpc {
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		}
 	}
 	return false
@@ -431,11 +430,7 @@ func (agentGrpc *agentGrpc) sendSqlMetadataWithRetry(sqlId int32, sql string) bo
 		}
 
 		if !agentGrpc.agent.config.offGrpc {
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		}
 	}
 	return false
@@ -471,11 +466,7 @@ func (agentGrpc *agentGrpc) sendSqlUidMetadataWithRetry(sqlUid []byte, sql strin
 		}
 
 		if !agentGrpc.agent.config.offGrpc {
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		}
 	}
 	return false
@@ -515,11 +506,7 @@ func (agentGrpc *agentGrpc) sendExceptionMetadataWithRetry(exception *exceptionM
 		}
 
 		if !agentGrpc.agent.config.offGrpc {
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
 		}
 	}
 	return false
@@ -617,27 +604,40 @@ func sendStreamWithTimeout(send func() error, timeout time.Duration, which strin
 	}
 }
 
-func waitUntilReady(grpcConn *grpc.ClientConn, timeout time.Duration, which string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+// waitUntilReady waits up to timeout for the connection to become ready. The
+// wait is bound to ctx as well, so cancelling ctx aborts it immediately.
+func waitUntilReady(ctx context.Context, grpcConn *grpc.ClientConn, timeout time.Duration, which string) bool {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	state := grpcConn.GetState()
 	Log("grpc").Infof("wait %s connection ready - state: %s, timeout: %s", which, state.String(), timeout.String())
 
 	for state != connectivity.Ready {
-		if grpcConn.WaitForStateChange(ctx, state) {
-			state = grpcConn.GetState()
-		} else {
-			// To exit IDLE state, it needs to try grpc action.
-			if state == connectivity.Idle && timeout.Seconds() > 30 {
-				return true
-			} else {
-				return false
-			}
+		// An IDLE channel never leaves that state on its own, so waiting on it
+		// would burn the whole interval; ask it to connect instead, mirroring
+		// the C++ agent's GetState(try_to_connect=true).
+		if state == connectivity.Idle {
+			grpcConn.Connect()
 		}
+		if !grpcConn.WaitForStateChange(ctx, state) {
+			return false
+		}
+		state = grpcConn.GetState()
 	}
 
 	return true
+}
+
+// backOffUntilReady waits for the connection to become ready, backing off
+// between attempts. It returns as soon as shutdown begins, so a pending
+// back-off interval does not delay it.
+func backOffUntilReady(agent *agent, grpcConn *grpc.ClientConn, which string) {
+	for attempt := 0; !agent.shutdown.Load(); attempt++ {
+		if waitUntilReady(agent.stopSignal(), grpcConn, backOffSleep(attempt), which) {
+			return
+		}
+	}
 }
 
 func newStreamWithRetry(agent *agent, grpcConn *grpc.ClientConn, newStreamFunc func() bool, which string) bool {
@@ -646,11 +646,7 @@ func newStreamWithRetry(agent *agent, grpcConn *grpc.ClientConn, newStreamFunc f
 			return true
 		}
 		if !agent.config.offGrpc {
-			for retry := 1; agent.Enable(); retry++ {
-				if waitUntilReady(grpcConn, backOffSleep(retry), which) {
-					break
-				}
-			}
+			backOffUntilReady(agent, grpcConn, which)
 		}
 	}
 	return false

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -1,10 +1,14 @@
 package pinpoint
 
 import (
+	"context"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 )
 
 func Test_agentGrpc_sendAgentInfo(t *testing.T) {
@@ -315,4 +319,68 @@ func Test_statStream_sendStatRetry(t *testing.T) {
 			assert.NoError(t, err, "sendStats")
 		})
 	}
+}
+
+func Test_backOffUntilReady_abortsOnShutdown(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	// Port 1 has no listener, so this connection never becomes ready and the
+	// back-off loop keeps waiting until it is told to stop.
+	conn, err := grpc.Dial("127.0.0.1:1", grpc.WithInsecure())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		backOffUntilReady(agent, conn, "test")
+	}()
+
+	// Let the goroutine reach the blocking wait. The first back-off interval is
+	// at least 2.1s, so returning within 1s can only be the stop signal.
+	time.Sleep(100 * time.Millisecond)
+	agent.signalShutdown()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Fatal("backOffUntilReady did not return within 1s of shutdown")
+	}
+}
+
+func Test_backOffSleep_rampsGentlyToCeiling(t *testing.T) {
+	// 3s x 1.2^attempt, clamped at 30s, then randomized by +/-30%.
+	wantMillis := []float64{
+		3000, 3600, 4320, 5184, 6220.8, 7464.96, 8957.952, 10749.5424,
+		12899.45088, 15479.341056, 18575.2092672, 22290.25112064,
+		26748.301344768, 30000,
+	}
+	for attempt, want := range wantMillis {
+		got := backOffSleep(attempt)
+		lo := time.Duration(want * (1 - backOffJitter) * float64(time.Millisecond))
+		hi := time.Duration(math.Ceil(want*(1+backOffJitter)) * float64(time.Millisecond))
+		assert.GreaterOrEqual(t, got, lo, "attempt %d", attempt)
+		assert.LessOrEqual(t, got, hi, "attempt %d", attempt)
+	}
+
+	// The ceiling holds once reached: 13 attempts of gentle ramp, unlike the
+	// base-2 ramp this replaced, which pinned itself in 4.
+	for attempt := len(wantMillis) - 1; attempt < 100; attempt++ {
+		got := backOffSleep(attempt)
+		assert.GreaterOrEqual(t, got, time.Duration(float64(backOffMaxInterval)*(1-backOffJitter)), "attempt %d", attempt)
+		assert.LessOrEqual(t, got, time.Duration(float64(backOffMaxInterval)*(1+backOffJitter)), "attempt %d", attempt)
+	}
+}
+
+func Test_waitUntilReady_connectsIdleChannel(t *testing.T) {
+	// NewClient, not Dial: it leaves the channel IDLE instead of connecting
+	// eagerly, which is the state this path exists for.
+	conn, err := grpc.NewClient("127.0.0.1:1", grpc.WithInsecure())
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	assert.Equal(t, connectivity.Idle, conn.GetState())
+	assert.False(t, waitUntilReady(context.Background(), conn, 200*time.Millisecond, "test"))
+	// An IDLE channel used to sit there for the whole interval; it must now
+	// have been asked to connect.
+	assert.NotEqual(t, connectivity.Idle, conn.GetState())
 }


### PR DESCRIPTION
Fixes #143.

The reconnect back-off was not a sleep: its only consumer was the `context.WithTimeout` inside `waitUntilReady`, parented on `context.Background()`. Both stop signals (`agent.shutdown`, `agent.enable`) are polled atomics, so nothing could wake a goroutine already inside that wait, and `Shutdown()` blocks on `connectWg.Wait()` with no bound — a shutdown landing during agent registration was held for up to a full 60s interval. The ramp itself also pinned to that 60s ceiling in 4 attempts.

## Changes

### 1. The wait becomes cancellable

```go
-func waitUntilReady(grpcConn *grpc.ClientConn, timeout time.Duration, which string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+func waitUntilReady(ctx context.Context, grpcConn *grpc.ClientConn, timeout time.Duration, which string) bool {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
```

The parent is a new `agent.stopSignal()`, cancelled where `Shutdown()` already sets the flag:

```go
-	agent.shutdown.Store(true)
+	agent.signalShutdown()
```

The polled flag stays — it is already the loop guard and is cheaper than `ctx.Err()` there; the context exists to unblock a wait in progress. It is created lazily under a `sync.Once` because the agent is built as a struct literal in four places, three of them test helpers: wiring it into each constructor would leave a nil-context panic waiting in whichever one gets missed.

**No slicing.** The C++ agent splits its delay into `backoff_sleep_slice` (1s) chunks and polls `stopping()` between them because gRPC's C++ `WaitForStateChange` accepts only a deadline. gRPC-Go's takes a context, so cancelling it aborts the wait immediately rather than within a slice.

### 2. Seven copies of the retry loop become one helper

The same five lines were duplicated at `registerAgentWithRetry`, the five metadata senders, and `newStreamWithRetry`:

```go
-			for retry := 1; agentGrpc.agent.Enable(); retry++ {
-				if waitUntilReady(agentGrpc.agentConn, backOffSleep(retry), "agent") {
-					break
-				}
-			}
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
```

```go
+func backOffUntilReady(agent *agent, grpcConn *grpc.ClientConn, which string) {
+	for attempt := 0; !agent.shutdown.Load(); attempt++ {
+		if waitUntilReady(agent.stopSignal(), grpcConn, backOffSleep(attempt), which) {
+			return
+		}
+	}
+}
```

This is load-bearing, not tidying. A loop still guarded by `agent.Enable()` would re-enter a wait that now returns immediately, busy-spinning at 100% CPU until `enable` is cleared — which happens only *after* `connectWg.Wait()` returns. The guard has to move to the stop signal in the same change that makes the wait cancellable.

### 3. The IDLE escape hatch becomes `ClientConn.Connect()`

```go
 	for state != connectivity.Ready {
-		if grpcConn.WaitForStateChange(ctx, state) {
-			state = grpcConn.GetState()
-		} else {
-			// To exit IDLE state, it needs to try grpc action.
-			if state == connectivity.Idle && timeout.Seconds() > 30 {
-				return true
-			} else {
-				return false
-			}
+		if state == connectivity.Idle {
+			grpcConn.Connect()
 		}
+		if !grpcConn.WaitForStateChange(ctx, state) {
+			return false
+		}
+		state = grpcConn.GetState()
 	}
```

An IDLE channel never changes state on its own, so this branch was the only way the wait ever handed control back to the caller's RPC retry — the thing that kicks the channel out of IDLE. It was coupled to the back-off ceiling: it can only fire while intervals above 30s are generated, so lowering the ceiling to 30s (§4) would have turned an IDLE channel into a permanent hang. `Connect()` asks the channel to leave IDLE directly, mirroring the C++ agent's `GetState(try_to_connect=true)`, and removes the coupling along with the 30s constant.

### 4. Parameters aligned with the C++ agent

```go
+	backOffInitialInterval = 3 * time.Second
+	backOffMultiplier      = 1.2
+	backOffMaxInterval     = 30 * time.Second
+	backOffJitter          = 0.3
```

Matching `GrpcClientTuning` (`src/grpc.h` L86-90). Un-jittered, the ramp goes 3s, 3.6, 4.3, 5.2, 6.2, 7.5, 9.0, 10.7, 12.9, 15.5, 18.6, 22.3, 26.7, 30 — 13 attempts to a ceiling half as high, where base 2 from 1s reached 60s on the 4th. As in `ExponentialBackoff::next_delay()` (`src/grpc.cpp` L144-163), the jitter is applied *after* the clamp, so a capped interval lands within ±30% of the ceiling instead of always on it.

The values stay constants. `GrpcClientTuning` has no reference outside `src/grpc.h` and `src/grpc.cpp` in the C++ agent — it is internal tuning, not user configuration, so there is nothing to expose here either.

## Tests

- `Test_backOffUntilReady_abortsOnShutdown` — enters the wait against a dead endpoint, signals shutdown, and requires a return within 1s. The first interval is at least 2.1s, so this cannot pass by coincidence.
- `Test_backOffSleep_rampsGentlyToCeiling` — the 14 un-jittered steps above, hardcoded, each within ±30%, then the ceiling held through attempt 100.
- `Test_waitUntilReady_connectsIdleChannel` — an IDLE channel is no longer IDLE after the wait. Pins the §3 replacement.

Both behavioural tests fail if the fix is reverted in place — parent restored to `context.Background()`, IDLE kick removed:

```
--- FAIL: Test_backOffUntilReady_abortsOnShutdown (1.10s)
    grpc_test.go:346: backOffUntilReady did not return within 1s of shutdown
--- FAIL: Test_waitUntilReady_connectsIdleChannel (0.20s)
        	Error:      	Should not be: 0
```

```
$ go test -race ./...
ok  	github.com/pinpoint-apm/pinpoint-go-agent	10.554s
```

## Not addressed

Two gaps found in this path, both out of scope here:

1. **`Shutdown()` can still wait out the registration RPC.** `sendAgentInfo` carries a `context.Background()`-derived 60s deadline (`agentGrpcTimeOut`), so a shutdown landing on the RPC leg of `registerAgentWithRetry` — rather than the back-off leg — is still held. Parenting `baseOutgoingContext()` on the stop signal is a one-line fix and the wrong one: it would also abort the in-flight span and metadata sends that #129 deliberately gives the workers 3s to finish. Either `connectWg.Wait()` needs the bound `workerWg` already has, or registration needs its own context.
2. **Stat queues are flushed as-is after a slow recovery.** The C++ agent times the reconnect and, past `slow_recovery_threshold` (5s), empties the stats queue and resets the accumulators behind it (`src/grpc.cpp` L281-310, L2158-2161). The Go agent drains `statChan` oldest-first with no notion of staleness, so a long outage replays minutes-old samples. Not a mechanical port — C++ swaps out a mutex-guarded `std::queue`, Go has a buffered channel whose consumer cannot skip ahead — so it needs its own change.
