### PR TITLE
[#153] Make span queue drop-oldest atomic, then shard producer contention

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -38,6 +38,11 @@ type agent struct {
 	statGrpc    *statGrpc
 	cmdGrpc     *cmdGrpc
 	spanChan    chan *spanChunk
+	// spanDropMu serializes the queue-full path of enqueueSpan; spanDropCount
+	// counts spans discarded there.
+	spanDropMu    sync.Mutex
+	spanDropCount atomic.Int64
+
 	metaChan    chan interface{}
 	urlStatChan chan *urlStat
 	statChan    chan *pb.PStatMessage
@@ -514,22 +519,34 @@ func (agent *agent) enqueueSpan(span *spanChunk) bool {
 		break
 	}
 
-	// When the queue is full, discard the oldest span
-	// and enqueue the newest so recent traces are favored under backpressure.
-	select {
-	case <-agent.spanChan:
-		if IsDebugLogLevelEnabled() {
-			Log("agent").Debugf("discard oldest span queue size:%d", len(agent.spanChan))
-		}
-	default:
-	}
+	// When the queue is full, discard the oldest span and enqueue the newest so
+	// recent traces are favored under backpressure. The mutex makes the
+	// drop-then-send pair atomic against other saturated producers; without it,
+	// another producer can fill the freed slot between the recv and the send,
+	// losing the new span on top of the dropped one. A fast-path send above can
+	// still take the slot, but that span was enqueued, so every drop counted
+	// below pairs with exactly one successful enqueue.
+	agent.spanDropMu.Lock()
+	defer agent.spanDropMu.Unlock()
 
-	select {
-	case agent.spanChan <- span:
-		return true
-	default:
-		return false
+	for agent.enable.Load() {
+		select {
+		case agent.spanChan <- span:
+			return true
+		default:
+		}
+
+		select {
+		case <-agent.spanChan:
+			agent.spanDropCount.Add(1)
+			if IsDebugLogLevelEnabled() {
+				Log("agent").Debugf("discard oldest span queue size:%d", len(agent.spanChan))
+			}
+		default:
+			// the consumer drained the queue between the two selects; resend
+		}
 	}
+	return false
 }
 
 func (agent *agent) sendMetaWorker() {

--- a/agent.go
+++ b/agent.go
@@ -37,12 +37,7 @@ type agent struct {
 	spanGrpc    *spanGrpc
 	statGrpc    *statGrpc
 	cmdGrpc     *cmdGrpc
-	spanChan    chan *spanChunk
-	// spanDropMu serializes the queue-full path of enqueueSpan; spanDropCount
-	// counts spans discarded there.
-	spanDropMu    sync.Mutex
-	spanDropCount atomic.Int64
-
+	spanQueue   *spanQueue
 	metaChan    chan interface{}
 	urlStatChan chan *urlStat
 	statChan    chan *pb.PStatMessage
@@ -187,7 +182,7 @@ func NewAgent(config *Config) (Agent, error) {
 		serviceName: config.objName.serviceName,
 		objName:     config.objName,
 		startTime:   time.Now().UnixNano() / int64(time.Millisecond),
-		spanChan:    make(chan *spanChunk, config.Int(CfgSpanQueueSize)),
+		spanQueue:   newSpanQueue(config.Int(CfgSpanQueueSize)),
 		metaChan:    make(chan interface{}, config.Int(CfgSpanQueueSize)),
 		urlStatChan: make(chan *urlStat, config.Int(CfgSpanQueueSize)),
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),
@@ -313,7 +308,7 @@ func (agent *agent) Shutdown() {
 
 	globalAgent = NoopAgent()
 
-	close(agent.spanChan)
+	agent.spanQueue.close()
 	close(agent.metaChan)
 	close(agent.statChan)
 	close(agent.urlStatChan)
@@ -449,8 +444,9 @@ func (agent *agent) sendSpanWorker() {
 	)
 
 	stream := agent.spanGrpc.newSpanStreamWithRetry()
-	for chunk := range agent.spanChan {
-		if !agent.enable.Load() {
+	for {
+		chunk, ok := agent.spanQueue.dequeue()
+		if !ok || !agent.enable.Load() {
 			break
 		}
 
@@ -488,19 +484,19 @@ func (agent *agent) sendSpanBatchWorker() {
 	// The first chunk starts a batch, collectSpanBatch opportunistically gathers more chunks,
 	// and sendSpanBatchAsync hands the batch to a bounded async sender.
 	for {
-		chunk, ok := <-agent.spanChan
+		chunk, ok := agent.spanQueue.dequeue()
 		if !ok {
 			break
 		}
 
-		batch, closed := agent.spanGrpc.collectSpanBatch(chunk, agent.spanChan)
+		batch, closed := agent.spanGrpc.collectSpanBatch(chunk, agent.spanQueue)
 		agent.spanGrpc.sendSpanBatchAsync(batch)
 		if closed {
 			break
 		}
 	}
 
-	// The span channel is closed during shutdown; wait for already accepted async batches
+	// The span queue is closed during shutdown; wait for already accepted async batches
 	// before the worker exits so queued spans get the same best-effort flush.
 	agent.spanGrpc.awaitInFlightSpanBatch()
 	Log("agent").Infof("end span batch goroutine")
@@ -510,43 +506,7 @@ func (agent *agent) enqueueSpan(span *spanChunk) bool {
 	if !agent.enable.Load() {
 		return false
 	}
-
-	// Fast path keeps enqueue non-blocking while the queue has capacity.
-	select {
-	case agent.spanChan <- span:
-		return true
-	default:
-		break
-	}
-
-	// When the queue is full, discard the oldest span and enqueue the newest so
-	// recent traces are favored under backpressure. The mutex makes the
-	// drop-then-send pair atomic against other saturated producers; without it,
-	// another producer can fill the freed slot between the recv and the send,
-	// losing the new span on top of the dropped one. A fast-path send above can
-	// still take the slot, but that span was enqueued, so every drop counted
-	// below pairs with exactly one successful enqueue.
-	agent.spanDropMu.Lock()
-	defer agent.spanDropMu.Unlock()
-
-	for agent.enable.Load() {
-		select {
-		case agent.spanChan <- span:
-			return true
-		default:
-		}
-
-		select {
-		case <-agent.spanChan:
-			agent.spanDropCount.Add(1)
-			if IsDebugLogLevelEnabled() {
-				Log("agent").Debugf("discard oldest span queue size:%d", len(agent.spanChan))
-			}
-		default:
-			// the consumer drained the queue between the two selects; resend
-		}
-	}
-	return false
+	return agent.spanQueue.enqueue(span)
 }
 
 func (agent *agent) sendMetaWorker() {
@@ -884,7 +844,7 @@ func NewTestAgent(config *Config, t *testing.T) (Agent, error) {
 		serviceName: config.objName.serviceName,
 		objName:     config.objName,
 		startTime:   time.Now().UnixNano() / int64(time.Millisecond),
-		spanChan:    make(chan *spanChunk, config.Int(CfgSpanQueueSize)),
+		spanQueue:   newSpanQueue(config.Int(CfgSpanQueueSize)),
 		metaChan:    make(chan interface{}, config.Int(CfgSpanQueueSize)),
 		urlStatChan: make(chan *urlStat, config.Int(CfgSpanQueueSize)),
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -49,9 +49,9 @@ func benchSpan(a *agent) *span {
 	return defaultSpan(a)
 }
 
-// startDrain consumes spanChan/metaChan in the background so enqueue stays on
-// its non-blocking fast path, mirroring production where the sender keeps up.
-// Without this, the buffered channels fill after ~1024 chunks and the benchmark
+// startDrain consumes the span queue/metaChan in the background so enqueue
+// stays on its non-saturated path, mirroring production where the sender keeps
+// up. Without this, the buffers fill after ~1024 chunks and the benchmark
 // would instead measure the queue-full drop path.
 func startDrain(a *agent) (stop func()) {
 	done := make(chan struct{})
@@ -60,10 +60,15 @@ func startDrain(a *agent) (stop func()) {
 	go func() {
 		defer wg.Done()
 		for {
+			for {
+				if _, ok := a.spanQueue.tryDequeue(); !ok {
+					break
+				}
+			}
 			select {
 			case <-done:
 				return
-			case <-a.spanChan:
+			case <-a.spanQueue.wake:
 			}
 		}
 	}()

--- a/grpc.go
+++ b/grpc.go
@@ -861,7 +861,7 @@ func (s *spanStream) sendSpan(chunk *spanChunk) error {
 // collectSpanBatch gathers the first span plus queued spans until batch size or collect deadline is reached.
 // The batch worker blocks for the first item, then uses a short collection window to improve
 // batch density without delaying sparse traffic too long.
-func (spanGrpc *spanGrpc) collectSpanBatch(first *spanChunk, spanChan <-chan *spanChunk) ([]*spanChunk, bool) {
+func (spanGrpc *spanGrpc) collectSpanBatch(first *spanChunk, queue *spanQueue) ([]*spanChunk, bool) {
 	batch := make([]*spanChunk, 0, spanGrpc.batchSize)
 	batch = append(batch, first)
 
@@ -869,12 +869,23 @@ func (spanGrpc *spanGrpc) collectSpanBatch(first *spanChunk, spanChan <-chan *sp
 	defer timer.Stop()
 
 	for len(batch) < spanGrpc.batchSize {
-		select {
-		case chunk, ok := <-spanChan:
-			if !ok {
-				return batch, true
-			}
+		if chunk, ok := queue.tryDequeue(); ok {
 			batch = append(batch, chunk)
+			continue
+		}
+		select {
+		case <-queue.wake:
+		case <-queue.done:
+			// Drain what remains; report closed only once the queue is empty so
+			// the worker comes back for a leftover larger than one batch.
+			for len(batch) < spanGrpc.batchSize {
+				chunk, ok := queue.tryDequeue()
+				if !ok {
+					return batch, true
+				}
+				batch = append(batch, chunk)
+			}
+			return batch, false
 		case <-timer.C:
 			return batch, false
 		}

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -3,6 +3,8 @@ package pinpoint
 import (
 	"context"
 	"math"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -227,6 +229,78 @@ func Test_agent_enqueueSpan_streamModeAlsoDiscardsOldest(t *testing.T) {
 
 	assert.Equal(t, second, <-agent.spanChan, "oldest span should be discarded")
 	assert.Equal(t, third, <-agent.spanChan, "newest span should be enqueued")
+}
+
+func Test_agent_enqueueSpan_saturatedConcurrentProducers(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	const queueCap = 8
+	agent.spanChan = make(chan *spanChunk, queueCap)
+	chunk := newTestSpanChunk(agent)
+
+	const producers = 16
+	const perProducer = 500
+
+	var consumed atomic.Int64
+	stop := make(chan struct{})
+	var consumerWg sync.WaitGroup
+	consumerWg.Add(1)
+	go func() {
+		defer consumerWg.Done()
+		for {
+			select {
+			case <-agent.spanChan:
+				consumed.Add(1)
+				time.Sleep(10 * time.Microsecond) // slow consumer keeps the queue saturated
+			case <-stop:
+				return
+			}
+		}
+	}()
+
+	var rejected atomic.Int64
+	var producerWg sync.WaitGroup
+	for i := 0; i < producers; i++ {
+		producerWg.Add(1)
+		go func() {
+			defer producerWg.Done()
+			for j := 0; j < perProducer; j++ {
+				if !agent.enqueueSpan(chunk) {
+					rejected.Add(1)
+				}
+				if n := len(agent.spanChan); n > queueCap {
+					t.Errorf("queue length %d exceeds capacity %d", n, queueCap)
+				}
+			}
+		}()
+	}
+	producerWg.Wait()
+	close(stop)
+	consumerWg.Wait()
+
+	remaining := int64(len(agent.spanChan))
+	dropped := agent.spanDropCount.Load()
+	assert.Zero(t, rejected.Load(), "a saturated queue must never lose the new span")
+	assert.Positive(t, dropped, "test must actually saturate the queue")
+	assert.Equal(t, int64(producers*perProducer), consumed.Load()+dropped+remaining,
+		"produced == consumed + dropped + remaining")
+}
+
+// Every enqueue exercises the queue-full drop-oldest path: the queue is
+// pre-filled and there is no consumer.
+func Benchmark_agent_enqueueSpan_saturated(b *testing.B) {
+	agent := newTestAgent(defaultConfig())
+	agent.spanChan = make(chan *spanChunk, cacheSize)
+	chunk := newTestSpanChunk(agent)
+	for i := 0; i < cacheSize; i++ {
+		agent.spanChan <- chunk
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			agent.enqueueSpan(chunk)
+		}
+	})
 }
 
 func Test_spanGrpc_collectSpanBatch_stopsAtBatchSize(t *testing.T) {

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -195,7 +195,7 @@ func Test_agent_enqueueSpan_discardsOldestAndEnqueuesNewest(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Set(CfgSpanBatchEnable, true)
 	agent := newTestAgent(cfg)
-	agent.spanChan = make(chan *spanChunk, 2)
+	agent.spanQueue = newSpanQueue(2) // single shard: FIFO is deterministic
 
 	first := newTestSpanChunk(agent)
 	second := newTestSpanChunk(agent)
@@ -205,8 +205,10 @@ func Test_agent_enqueueSpan_discardsOldestAndEnqueuesNewest(t *testing.T) {
 	assert.True(t, agent.enqueueSpan(second), "enqueue second")
 	assert.True(t, agent.enqueueSpan(third), "enqueue third")
 
-	assert.Equal(t, second, <-agent.spanChan, "oldest span should be discarded")
-	assert.Equal(t, third, <-agent.spanChan, "newest span should be enqueued")
+	got, _ := agent.spanQueue.tryDequeue()
+	assert.Equal(t, second, got, "oldest span should be discarded")
+	got, _ = agent.spanQueue.tryDequeue()
+	assert.Equal(t, third, got, "newest span should be enqueued")
 }
 
 func Test_agent_enqueueSpan_streamModeAlsoDiscardsOldest(t *testing.T) {
@@ -217,7 +219,7 @@ func Test_agent_enqueueSpan_streamModeAlsoDiscardsOldest(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Set(CfgSpanBatchEnable, false)
 	agent := newTestAgent(cfg)
-	agent.spanChan = make(chan *spanChunk, 2)
+	agent.spanQueue = newSpanQueue(2) // single shard: FIFO is deterministic
 
 	first := newTestSpanChunk(agent)
 	second := newTestSpanChunk(agent)
@@ -227,33 +229,32 @@ func Test_agent_enqueueSpan_streamModeAlsoDiscardsOldest(t *testing.T) {
 	assert.True(t, agent.enqueueSpan(second), "enqueue second")
 	assert.True(t, agent.enqueueSpan(third), "newest span is enqueued after discarding the oldest")
 
-	assert.Equal(t, second, <-agent.spanChan, "oldest span should be discarded")
-	assert.Equal(t, third, <-agent.spanChan, "newest span should be enqueued")
+	got, _ := agent.spanQueue.tryDequeue()
+	assert.Equal(t, second, got, "oldest span should be discarded")
+	got, _ = agent.spanQueue.tryDequeue()
+	assert.Equal(t, third, got, "newest span should be enqueued")
 }
 
 func Test_agent_enqueueSpan_saturatedConcurrentProducers(t *testing.T) {
 	agent := newTestAgent(defaultConfig())
-	const queueCap = 8
-	agent.spanChan = make(chan *spanChunk, queueCap)
+	const queueCap = 256 // 8 shards of 32
+	agent.spanQueue = newSpanQueue(queueCap)
 	chunk := newTestSpanChunk(agent)
 
 	const producers = 16
 	const perProducer = 500
 
 	var consumed atomic.Int64
-	stop := make(chan struct{})
 	var consumerWg sync.WaitGroup
 	consumerWg.Add(1)
 	go func() {
 		defer consumerWg.Done()
 		for {
-			select {
-			case <-agent.spanChan:
-				consumed.Add(1)
-				time.Sleep(10 * time.Microsecond) // slow consumer keeps the queue saturated
-			case <-stop:
+			if _, ok := agent.spanQueue.dequeue(); !ok {
 				return
 			}
+			consumed.Add(1)
+			time.Sleep(10 * time.Microsecond) // slow consumer keeps the queue saturated
 		}
 	}()
 
@@ -267,32 +268,50 @@ func Test_agent_enqueueSpan_saturatedConcurrentProducers(t *testing.T) {
 				if !agent.enqueueSpan(chunk) {
 					rejected.Add(1)
 				}
-				if n := len(agent.spanChan); n > queueCap {
+				if n := agent.spanQueue.length(); n > queueCap {
 					t.Errorf("queue length %d exceeds capacity %d", n, queueCap)
 				}
 			}
 		}()
 	}
 	producerWg.Wait()
-	close(stop)
+	agent.spanQueue.close() // the consumer drains the rest, then dequeue reports done
 	consumerWg.Wait()
 
-	remaining := int64(len(agent.spanChan))
-	dropped := agent.spanDropCount.Load()
+	dropped := agent.spanQueue.dropCount()
 	assert.Zero(t, rejected.Load(), "a saturated queue must never lose the new span")
 	assert.Positive(t, dropped, "test must actually saturate the queue")
-	assert.Equal(t, int64(producers*perProducer), consumed.Load()+dropped+remaining,
-		"produced == consumed + dropped + remaining")
+	assert.Zero(t, agent.spanQueue.length(), "consumer must drain the closed queue")
+	assert.Equal(t, int64(producers*perProducer), consumed.Load()+dropped,
+		"produced == consumed + dropped")
+}
+
+// Multi-producer enqueue with a draining consumer: the producer-contention
+// path a loaded service exercises on every request.
+func Benchmark_agent_enqueueSpan_parallel(b *testing.B) {
+	agent := newTestAgent(defaultConfig())
+	stop := startDrain(agent)
+	defer stop()
+	chunk := newTestSpanChunk(agent)
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			agent.enqueueSpan(chunk)
+		}
+	})
 }
 
 // Every enqueue exercises the queue-full drop-oldest path: the queue is
 // pre-filled and there is no consumer.
 func Benchmark_agent_enqueueSpan_saturated(b *testing.B) {
 	agent := newTestAgent(defaultConfig())
-	agent.spanChan = make(chan *spanChunk, cacheSize)
+	agent.spanQueue = newSpanQueue(cacheSize)
 	chunk := newTestSpanChunk(agent)
-	for i := 0; i < cacheSize; i++ {
-		agent.spanChan <- chunk
+	for i := range agent.spanQueue.shards {
+		shard := &agent.spanQueue.shards[i]
+		for shard.tryEnqueue(chunk) {
+		}
 	}
 
 	b.ResetTimer()
@@ -312,18 +331,18 @@ func Test_spanGrpc_collectSpanBatch_stopsAtBatchSize(t *testing.T) {
 	first := newTestSpanChunk(agent)
 	second := newTestSpanChunk(agent)
 	third := newTestSpanChunk(agent)
-	spanChan := make(chan *spanChunk, 2)
-	spanChan <- second
-	spanChan <- third
+	queue := newSpanQueue(2)
+	queue.enqueue(second)
+	queue.enqueue(third)
 
-	batch, closed := spanGrpc.collectSpanBatch(first, spanChan)
+	batch, closed := spanGrpc.collectSpanBatch(first, queue)
 
 	assert.False(t, closed)
 	assert.Equal(t, []*spanChunk{first, second}, batch)
-	assert.Equal(t, 1, len(spanChan), "third chunk should wait for the next batch")
+	assert.Equal(t, 1, queue.length(), "third chunk should wait for the next batch")
 }
 
-func Test_spanGrpc_collectSpanBatch_flushesClosedChannel(t *testing.T) {
+func Test_spanGrpc_collectSpanBatch_flushesClosedQueue(t *testing.T) {
 	agent := newTestAgent(defaultConfig())
 	spanGrpc := newMockSpanGrpc(agent, t)
 	spanGrpc.batchSize = 50
@@ -331,11 +350,11 @@ func Test_spanGrpc_collectSpanBatch_flushesClosedChannel(t *testing.T) {
 
 	first := newTestSpanChunk(agent)
 	second := newTestSpanChunk(agent)
-	spanChan := make(chan *spanChunk, 1)
-	spanChan <- second
-	close(spanChan)
+	queue := newSpanQueue(1)
+	queue.enqueue(second)
+	queue.close()
 
-	batch, closed := spanGrpc.collectSpanBatch(first, spanChan)
+	batch, closed := spanGrpc.collectSpanBatch(first, queue)
 
 	assert.True(t, closed)
 	assert.Equal(t, []*spanChunk{first, second}, batch)

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -20,7 +20,7 @@ func newTestAgent(config *Config) *agent {
 		agentID:   "testAgent",
 		appType:   ServiceTypeGoApp,
 		startTime: time.Now().UnixNano() / int64(time.Millisecond),
-		spanChan:  make(chan *spanChunk, cacheSize),
+		spanQueue: newSpanQueue(cacheSize),
 		metaChan:  make(chan interface{}, cacheSize),
 		config:    config,
 		objName: &objectName{

--- a/span_queue.go
+++ b/span_queue.go
@@ -1,0 +1,238 @@
+package pinpoint
+
+import (
+	"math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	spanQueueMaxShards   = 32
+	spanQueueMinShardCap = 32
+)
+
+// spanQueue is a bounded multi-producer queue with producer contention sharded
+// across independently locked ring buffers, replacing the single channel whose
+// internal mutex every producer met on. Capacity stays the configured global
+// bound; rings are preallocated so the enqueue path never allocates.
+//
+// Shards are picked per enqueue with math/rand/v2 (per-thread state, no shared
+// cache line) rather than a sticky per-goroutine home shard: Go has no stable
+// cheap goroutine identity, and non-sticky placement also lets a single busy
+// producer spread over every shard, so the whole capacity is used without the
+// C++ agent's quota-borrowing machinery. Head-drop on a full shard happens in
+// the same critical section as the enqueue, so a drop is always paired with
+// exactly one successful enqueue.
+//
+// Concurrency contract: multi-producer, single consumer. cursor is a plain
+// field, so two concurrent dequeuers are a data race, not merely an
+// unspecified order. Cross-shard dequeue order is unspecified.
+type spanQueue struct {
+	shards []spanQueueShard
+
+	// wake carries at most one token; enqueue tops it up and the consumer
+	// sweeps every shard per token, so coalesced wake-ups lose nothing.
+	wake   chan struct{}
+	done   chan struct{}
+	closed atomic.Bool
+
+	// cursor rotates the consumer's sweep start so a persistently hot shard
+	// cannot starve the others. Only the single consumer touches it; the pad
+	// keeps its writes off the line producers read closed from.
+	_      [cacheLinePadSize]byte
+	cursor int
+}
+
+type spanQueueShardInternal struct {
+	mu    sync.Mutex
+	cells []*spanChunk
+	head  int
+	size  int
+	drops int64
+}
+
+// spanQueueShard gives every shard its own cache line, same reasoning and
+// stride as activeSpanShard.
+type spanQueueShard struct {
+	spanQueueShardInternal
+	_ [cacheLinePadSize - unsafe.Sizeof(spanQueueShardInternal{})%cacheLinePadSize]byte
+}
+
+func newSpanQueue(capacity int) *spanQueue {
+	if capacity < 1 {
+		capacity = 1
+	}
+	// Tiny queues gain no useful contention reduction from near-empty shards
+	// and would unnecessarily relax their FIFO behavior.
+	shardCount := capacity / spanQueueMinShardCap
+	if shardCount > spanQueueMaxShards {
+		shardCount = spanQueueMaxShards
+	}
+	if shardCount < 1 {
+		shardCount = 1
+	}
+
+	q := &spanQueue{
+		shards: make([]spanQueueShard, shardCount),
+		wake:   make(chan struct{}, 1),
+		done:   make(chan struct{}),
+	}
+	base := capacity / shardCount
+	extra := capacity % shardCount
+	for i := range q.shards {
+		shardCap := base
+		if i < extra {
+			shardCap++
+		}
+		q.shards[i].cells = make([]*spanChunk, shardCap)
+	}
+	return q
+}
+
+// enqueue never blocks and, until close, never rejects: a full shard head-drops
+// its oldest chunk in the same critical section, so recent traces are favored
+// under backpressure. Trying a second shard first keeps a momentarily full
+// shard from dropping while the queue as a whole still has room.
+func (q *spanQueue) enqueue(chunk *spanChunk) bool {
+	if q.closed.Load() {
+		return false
+	}
+
+	first := rand.IntN(len(q.shards))
+	if q.shards[first].tryEnqueue(chunk) {
+		q.notify()
+		return true
+	}
+	second := rand.IntN(len(q.shards))
+	if second != first && q.shards[second].tryEnqueue(chunk) {
+		q.notify()
+		return true
+	}
+	q.shards[second].enqueueOrOverwrite(chunk)
+	q.notify()
+	return true
+}
+
+// dequeue blocks until a chunk is available, and reports false once the queue
+// is closed and fully drained.
+func (q *spanQueue) dequeue() (*spanChunk, bool) {
+	for {
+		if chunk, ok := q.tryDequeue(); ok {
+			return chunk, true
+		}
+		select {
+		case <-q.wake:
+		case <-q.done:
+			// A producer may have enqueued between the failed sweep and the
+			// close; drain rather than trusting that sweep.
+			return q.tryDequeue()
+		}
+	}
+}
+
+// tryDequeue sweeps the shards round-robin from the cursor and never blocks.
+func (q *spanQueue) tryDequeue() (*spanChunk, bool) {
+	for i := 0; i < len(q.shards); i++ {
+		shard := (q.cursor + i) % len(q.shards)
+		if chunk, ok := q.shards[shard].tryDequeue(); ok {
+			q.cursor = (shard + 1) % len(q.shards)
+			return chunk, true
+		}
+	}
+	return nil, false
+}
+
+// close stops the queue: subsequent enqueues are rejected and the consumer is
+// woken to drain what remains. Safe to call once (guarded by the caller, like
+// the channel close it replaces).
+func (q *spanQueue) close() {
+	q.closed.Store(true)
+	close(q.done)
+}
+
+func (q *spanQueue) notify() {
+	select {
+	case q.wake <- struct{}{}:
+	default:
+	}
+}
+
+func (q *spanQueue) dropCount() int64 {
+	var total int64
+	for i := range q.shards {
+		s := &q.shards[i]
+		s.mu.Lock()
+		total += s.drops
+		s.mu.Unlock()
+	}
+	return total
+}
+
+func (q *spanQueue) length() int {
+	var total int
+	for i := range q.shards {
+		s := &q.shards[i]
+		s.mu.Lock()
+		total += s.size
+		s.mu.Unlock()
+	}
+	return total
+}
+
+func (s *spanQueueShard) tryEnqueue(chunk *spanChunk) bool {
+	s.mu.Lock()
+	if s.size == len(s.cells) {
+		s.mu.Unlock()
+		return false
+	}
+	s.push(chunk)
+	s.mu.Unlock()
+	return true
+}
+
+func (s *spanQueueShard) enqueueOrOverwrite(chunk *spanChunk) {
+	s.mu.Lock()
+	if s.size == len(s.cells) {
+		s.cells[s.head] = nil
+		s.head = s.next(s.head)
+		s.size--
+		s.drops++
+		if IsDebugLogLevelEnabled() {
+			Log("agent").Debugf("discard oldest span, shard size:%d", s.size)
+		}
+	}
+	s.push(chunk)
+	s.mu.Unlock()
+}
+
+func (s *spanQueueShard) tryDequeue() (*spanChunk, bool) {
+	s.mu.Lock()
+	if s.size == 0 {
+		s.mu.Unlock()
+		return nil, false
+	}
+	chunk := s.cells[s.head]
+	s.cells[s.head] = nil
+	s.head = s.next(s.head)
+	s.size--
+	s.mu.Unlock()
+	return chunk, true
+}
+
+func (s *spanQueueShard) push(chunk *spanChunk) {
+	tail := s.head + s.size
+	if tail >= len(s.cells) {
+		tail -= len(s.cells)
+	}
+	s.cells[tail] = chunk
+	s.size++
+}
+
+func (s *spanQueueShard) next(position int) int {
+	position++
+	if position == len(s.cells) {
+		return 0
+	}
+	return position
+}

--- a/span_queue_test.go
+++ b/span_queue_test.go
@@ -1,0 +1,64 @@
+package pinpoint
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test_spanQueueShardIsCacheLinePadded guards the false-sharing fix: the shards
+// must stay a whole cache line apart, not packed several to a line.
+func Test_spanQueueShardIsCacheLinePadded(t *testing.T) {
+	if got := unsafe.Sizeof(spanQueueShard{}); got%cacheLinePadSize != 0 {
+		t.Errorf("spanQueueShard is %d bytes, not a multiple of the %d-byte shard stride: shards share a cache line", got, cacheLinePadSize)
+	}
+}
+
+func Test_spanQueue_shardCapacitySumsToCapacity(t *testing.T) {
+	for _, capacity := range []int{1, 2, 31, 32, 33, 256, 1000, 1024, 4096} {
+		q := newSpanQueue(capacity)
+		total := 0
+		for i := range q.shards {
+			total += len(q.shards[i].cells)
+		}
+		assert.Equal(t, capacity, total, "capacity %d", capacity)
+		assert.LessOrEqual(t, len(q.shards), spanQueueMaxShards, "capacity %d", capacity)
+	}
+}
+
+// Test_spanQueue_singleProducerUsesFullCapacity is the scenario that motivated
+// the C++ agent's quota borrowing: consumer stalled, one producer. Non-sticky
+// shard placement must retain the full configured capacity, not one shard's
+// slice of it.
+func Test_spanQueue_singleProducerUsesFullCapacity(t *testing.T) {
+	const capacity = 1024
+	q := newSpanQueue(capacity)
+	agent := newTestAgent(defaultConfig())
+	chunk := newTestSpanChunk(agent)
+
+	enqueued := 20 * capacity // enough for random placement to hit every shard
+	for i := 0; i < enqueued; i++ {
+		assert.True(t, q.enqueue(chunk))
+	}
+
+	assert.Equal(t, capacity, q.length(), "retained spans must fill the whole buffer")
+	assert.Equal(t, int64(enqueued-capacity), q.dropCount(),
+		"every enqueue beyond capacity is a counted drop")
+}
+
+func Test_spanQueue_closeRejectsEnqueueAndReportsDone(t *testing.T) {
+	q := newSpanQueue(32)
+	agent := newTestAgent(defaultConfig())
+	chunk := newTestSpanChunk(agent)
+
+	assert.True(t, q.enqueue(chunk))
+	q.close()
+	assert.False(t, q.enqueue(chunk), "enqueue after close is rejected")
+
+	got, ok := q.dequeue()
+	assert.True(t, ok, "closed queue still drains what it holds")
+	assert.Equal(t, chunk, got)
+	_, ok = q.dequeue()
+	assert.False(t, ok, "drained closed queue reports done")
+}


### PR DESCRIPTION
Closes #153.

The span queue was one buffered channel: every producer met on the channel's internal mutex, and the queue-full drop-oldest path was a non-atomic try-send → try-recv → try-send sequence that could lose the new span on top of the one it dropped. Two commits, each independently revertible:

## 1. Make drop-oldest atomic (behavior fix)

Serializes the queue-full path behind a mutex and retries the send after each drop, so every drop pairs with exactly one successful enqueue and the new span is never lost. On origin/main, a saturated queue with 10 concurrent producers lost the new span on 0.3% of one million enqueues — each loss also having already dropped an oldest span, i.e. two spans gone for zero enqueued. Adds a drop counter and a multi-producer saturation test asserting no rejection, the capacity bound, and the `produced == consumed + dropped + remaining` conservation equation.

## 2. Shard the queue (contention fix)

Replaces the channel with `spanQueue`: `min(32, capacity/32)` shards, each an independently locked preallocated ring, shard capacities summing to the configured `Span.QueueSize`. Design points, following the C++ agent's `ShardedBoundedQueue` where it transfers and deviating where Go differs:

- **Shard choice is per enqueue** (`math/rand/v2`, per-thread state, no shared cache line) **plus a second-choice probe**, not a sticky per-goroutine home shard: Go has no stable cheap goroutine identity (goid needs an unsafe asm dependency; `runtime_procPin` linkname is blocked since Go 1.23). Non-sticky placement also lets a single busy producer spread over every shard, so the whole buffer is retained without porting the C++ quota-borrowing machinery — a test pins the motivating scenario (consumer stalled, one producer, retained spans == full 1024 capacity).
- **Head-drop shares the enqueue's critical section**, keeping commit 1's drop/enqueue pairing; commit 1's producer-side retry mutex is deleted.
- **Shards are padded to the 128-byte stride** `activeSpanShard` uses (#141), with the same layout guard test.
- **Single consumer multiplexes with a one-token wake channel and a round-robin cursor**, so a hot shard cannot starve the others. `close()` signals a done channel and the consumer drains what remains — which also removes the old shutdown race where `enqueueSpan` could hit a closed channel and panic.

## Benchmarks (M1 Pro, median of 6)

vs the commit-1 baseline:

| benchmark | -cpu | before | after | change |
|---|---|---|---|---|
| enqueue, draining consumer | 4 | 106.6 ns | 36.6 ns | **-66%** |
| | 10 | 118.9 ns | 59.3 ns | **-50%** |
| enqueue, saturated drop path | 1 | 36.9 ns | 42.3 ns | +15% |
| | 4 | 105.5 ns | 30.1 ns | **-71%** |
| | 10 | 136.3 ns | 53.1 ns | **-61%** |
| SpanLifecycleParallel (end-to-end) | 4 | 626 ns | 544 ns | -13% |
| | 10 | 1053 ns | 778 ns | **-26%** |

The single-core +15% on the drop path is the two rand calls and the second-choice probe, repaid from two cores up. The saturated path at -cpu=10 is faster than the pre-fix non-atomic sequence (135 ns → 53 ns vs main's 46 ns) while never losing the new span.

`go test -race ./...` passes on both commits.
