### PR TITLE
[#157] Cancel the stream on send timeout instead of abandoning a goroutine

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -379,14 +379,14 @@ func BenchmarkSetSQL(b *testing.B) {
 }
 
 // BenchmarkSendStreamWithTimeout measures the per-send overhead of the timeout
-// wrapper used by the streaming span/ping/stat/command senders (goroutine +
-// channel + timer per Send). The send itself is a no-op so the result is pure
-// wrapper overhead.
+// wrapper used by the streaming span/ping/stat/command senders (now one timer
+// per Send, no goroutine or channel). The send itself is a no-op so the result
+// is pure wrapper overhead.
 func BenchmarkSendStreamWithTimeout(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = sendStreamWithTimeout(func() error { return nil }, 5*time.Second, "bench")
+		_ = sendStreamWithTimeout(func() error { return nil }, func() {}, 5*time.Second, "bench")
 	}
 }
 

--- a/grpc.go
+++ b/grpc.go
@@ -11,6 +11,7 @@ import (
 	"runtime/debug"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -558,50 +559,24 @@ func makePStackTraceElementList(frames []frame) []*pb.PStackTraceElement {
 	return list
 }
 
-// streamTimerPool reuses timers across stream Send timeouts. A timer carries an
-// internal channel, so pooling avoids allocating both the *time.Timer and that
-// channel on every send.
-var streamTimerPool = sync.Pool{
-	New: func() interface{} {
-		t := time.NewTimer(time.Hour)
-		t.Stop()
-		return t
-	},
-}
-
-func acquireStreamTimer(d time.Duration) *time.Timer {
-	t := streamTimerPool.Get().(*time.Timer)
-	t.Reset(d)
-	return t
-}
-
-func releaseStreamTimer(t *time.Timer) {
-	if !t.Stop() {
-		// drain a possibly-fired timer so the reused timer starts empty
-		select {
-		case <-t.C:
-		default:
-		}
+// sendStreamWithTimeout runs op on the calling goroutine and cancels the
+// stream if op blocks past timeout. grpc-go unblocks a flow-control-blocked
+// Send/Recv/CloseSend once the stream context is cancelled, so nothing is
+// spawned or abandoned — the Go analog of the C++ agent's bounded wait plus
+// TryCancel. Killing the stream on timeout matches the callers: they already
+// close and re-create the stream on any send error.
+func sendStreamWithTimeout(op func() error, cancelStream context.CancelFunc, timeout time.Duration, which string) error {
+	var timedOut atomic.Bool
+	t := time.AfterFunc(timeout, func() {
+		timedOut.Store(true)
+		cancelStream()
+	})
+	err := op()
+	t.Stop()
+	if timedOut.Load() {
+		return status.Errorf(codes.DeadlineExceeded, which+" - too slow or blocked")
 	}
-	streamTimerPool.Put(t)
-}
-
-func sendStreamWithTimeout(send func() error, timeout time.Duration, which string) error {
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- send()
-		close(errChan)
-	}()
-
-	t := acquireStreamTimer(timeout)
-	defer releaseStreamTimer(t)
-
-	select {
-	case <-t.C:
-		return status.Errorf(codes.DeadlineExceeded, which+" stream.Send() - too slow or blocked")
-	case err := <-errChan:
-		return err
-	}
+	return err
 }
 
 // waitUntilReady waits up to timeout for the connection to become ready. The
@@ -685,29 +660,19 @@ func (s *pingStream) sendPing() error {
 	if s.stream == nil {
 		return status.Errorf(codes.Unavailable, "ping stream is nil")
 	}
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(&ping) }, sendStreamTimeOut, "ping")
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(&ping) }, s.cancel, sendStreamTimeOut, "ping stream.Send()")
 	if err != nil {
 		s.cancel()
 		return err
 	}
 
-	errChan := make(chan error, 1)
-	go func() {
-		_, err = s.stream.Recv()
-		errChan <- err
-		close(errChan)
-	}()
-
-	t := time.NewTimer(sendStreamTimeOut)
-	select {
-	case <-t.C:
-		return status.Errorf(codes.DeadlineExceeded, "ping stream.Recv() - too slow or blocked")
-	case err = <-errChan:
-		if !t.Stop() {
-			<-t.C
-		}
-		return err
-	}
+	return sendStreamWithTimeout(
+		func() error {
+			_, err := s.stream.Recv()
+			return err
+		},
+		s.cancel, sendStreamTimeOut, "ping stream.Recv()",
+	)
 }
 
 func (s *pingStream) close() {
@@ -716,7 +681,7 @@ func (s *pingStream) close() {
 	}
 	defer s.cancel()
 
-	sendStreamWithTimeout(func() error { return s.stream.CloseSend() }, closeStreamTimeOut, "ping")
+	sendStreamWithTimeout(func() error { return s.stream.CloseSend() }, s.cancel, closeStreamTimeOut, "ping stream.CloseSend()")
 	s.stream = nil
 	Log("grpc").Infof("close ping stream")
 }
@@ -825,7 +790,7 @@ func (s *spanStream) close() {
 			_, err := s.stream.CloseAndRecv()
 			return err
 		},
-		closeStreamTimeOut, "span",
+		s.cancel, closeStreamTimeOut, "span stream.CloseAndRecv()",
 	)
 	s.stream = nil
 	Log("grpc").Infof("close span stream")
@@ -851,7 +816,7 @@ func (s *spanStream) sendSpan(chunk *spanChunk) error {
 		Log("grpc").Tracef("PSpanMessage: %s", gspan.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(gspan) }, sendStreamTimeOut, "span")
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(gspan) }, s.cancel, sendStreamTimeOut, "span stream.Send()")
 	if err != nil {
 		s.cancel()
 	}
@@ -1233,7 +1198,7 @@ func (s *statStream) close() {
 			_, err := s.stream.CloseAndRecv()
 			return err
 		},
-		closeStreamTimeOut, "stat",
+		s.cancel, closeStreamTimeOut, "stat stream.CloseAndRecv()",
 	)
 	s.stream = nil
 	Log("grpc").Infof("close stat stream")
@@ -1247,7 +1212,7 @@ func (s *statStream) sendStats(stats *pb.PStatMessage) error {
 		Log("grpc").Tracef("PStatMessage: %s", stats.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(stats) }, sendStreamTimeOut, "stat")
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(stats) }, s.cancel, sendStreamTimeOut, "stat stream.Send()")
 	if err != nil {
 		s.cancel()
 	}
@@ -1414,7 +1379,7 @@ func (s *cmdStream) close() {
 	}
 	defer s.cancel()
 
-	sendStreamWithTimeout(func() error { return s.stream.CloseSend() }, closeStreamTimeOut, "cmd")
+	sendStreamWithTimeout(func() error { return s.stream.CloseSend() }, s.cancel, closeStreamTimeOut, "cmd stream.CloseSend()")
 	s.stream = nil
 	Log("grpc").Infof("close command stream")
 }
@@ -1444,7 +1409,7 @@ func (s *cmdStream) sendCommandMessage() error {
 		Log("grpc").Debugf("PCmdMessage: %s", gCmd.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(gCmd) }, sendStreamTimeOut, "cmd")
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(gCmd) }, s.cancel, sendStreamTimeOut, "cmd stream.Send()")
 	if err != nil {
 		s.cancel()
 	}
@@ -1499,7 +1464,7 @@ func (s *activeThreadCountStream) close() {
 			_, err := s.stream.CloseAndRecv()
 			return err
 		},
-		closeStreamTimeOut, "arc",
+		s.cancel, closeStreamTimeOut, "arc stream.CloseAndRecv()",
 	)
 	s.stream = nil
 }
@@ -1530,7 +1495,7 @@ func (s *activeThreadCountStream) sendActiveThreadCount() error {
 		Log("grpc").Debugf("PCmdActiveThreadCountRes: %s", gRes.String())
 	}
 
-	err := sendStreamWithTimeout(func() error { return s.stream.Send(gRes) }, sendStreamTimeOut, "arc")
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(gRes) }, s.cancel, sendStreamTimeOut, "arc stream.Send()")
 	if err != nil {
 		s.cancel()
 	}

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -3,6 +3,7 @@ package pinpoint
 import (
 	"context"
 	"math"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -10,7 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/status"
 )
 
 func Test_agentGrpc_sendAgentInfo(t *testing.T) {
@@ -476,4 +479,39 @@ func Test_waitUntilReady_connectsIdleChannel(t *testing.T) {
 	// An IDLE channel used to sit there for the whole interval; it must now
 	// have been asked to connect.
 	assert.NotEqual(t, connectivity.Idle, conn.GetState())
+}
+
+func Test_sendStreamWithTimeout_passesThroughResult(t *testing.T) {
+	assert.NoError(t, sendStreamWithTimeout(func() error { return nil }, func() {}, time.Second, "test"))
+
+	sendErr := status.Errorf(codes.Internal, "boom")
+	assert.Equal(t, sendErr, sendStreamWithTimeout(func() error { return sendErr }, func() {}, time.Second, "test"))
+}
+
+// An unresponsive stream: Send blocks until the stream context is cancelled,
+// which is how a grpc-go Send stuck on flow control behaves. The wrapper must
+// unblock it via cancel and, running the send on the calling goroutine, leave
+// no goroutines behind no matter how many sends time out.
+func Test_sendStreamWithTimeout_unresponsiveStreamLeaksNothing(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 100; i++ {
+		ctx, cancel := context.WithCancel(context.Background())
+		err := sendStreamWithTimeout(
+			func() error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			cancel, time.Millisecond, "test stream.Send()",
+		)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	}
+
+	// Allow the fired AfterFunc callbacks to finish; they are the only
+	// transient goroutines this path may create.
+	deadline := time.Now().Add(time.Second)
+	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.LessOrEqual(t, runtime.NumGoroutine(), before+2)
 }


### PR DESCRIPTION
Fixes #157

## What

`sendStreamWithTimeout` used to run `send()` on a freshly spawned goroutine, race it against a timer, and on timeout return `DeadlineExceeded` while abandoning the goroutine — along with the error channel and the serialized message its closure held. Reclamation depended on each caller separately cancelling the stream context afterwards, and the ping `Recv()` path (an inlined copy of the same pattern) never did.

This change runs the send on the calling goroutine and arms `time.AfterFunc(timeout, cancelStream)`. grpc-go unblocks a flow-control-blocked `Send`/`Recv`/`CloseSend` once the stream context is cancelled, so a timed-out send is actively unblocked instead of orphaned — the Go analog of the C++ agent's bounded wait + `TryCancel` (`stream_write_timeout` in src/grpc.h). Cancelling on timeout matches existing semantics: every caller already closes and re-creates the stream on a send timeout.

- Zero goroutines and zero channel allocations per stream send (ping/span/stat/cmd/arc, send and close paths).
- The ping `Recv()` timeout block folds into the same helper, gaining its missing cancellation and dropping a benign data race on its captured `err`.
- `streamTimerPool` deleted — `AfterFunc` timers carry no channel, so there is nothing left worth pooling.
- Timeout errors keep `codes.DeadlineExceeded`; callers' close-and-recreate flow is unchanged.

## Verification

- New `Test_sendStreamWithTimeout_unresponsiveStreamLeaksNothing`: a send that blocks until the stream context is cancelled (how a Send stuck on flow control behaves against an unresponsive collector) is timed out 100 times; `runtime.NumGoroutine()` returns to its starting level.
- `go test -race ./...` passes.
- `BenchmarkSendStreamWithTimeout`: 659 ns/op, 152 B/op → 124 ns/op, 140 B/op.
