### PR TITLE
[#156] Replace the FIFO-order metadata caches with a sharded LRU using aged promotion

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 	"github.com/spaolacci/murmur3"
 )
@@ -42,12 +41,12 @@ type agent struct {
 	urlStatChan chan *urlStat
 	statChan    chan *pb.PStatMessage
 
-	errorCache  *lru.Cache
+	errorCache  *metaCache[string, int32]
 	errorIdGen  int32
-	sqlCache    *lru.Cache
+	sqlCache    *metaCache[string, int32]
 	sqlIdGen    int32
-	sqlUidCache *lru.Cache
-	apiCache    *lru.Cache
+	sqlUidCache *metaCache[string, []byte]
+	apiCache    *metaCache[apiCacheKey, int32]
 	apiIdGen    int32
 
 	config    *Config
@@ -189,19 +188,10 @@ func NewAgent(config *Config) (Agent, error) {
 		config:      config,
 	}
 
-	var err error
-	if agent.errorCache, err = lru.New(cacheSize); err != nil {
-		return NoopAgent(), err
-	}
-	if agent.sqlCache, err = lru.New(cacheSize); err != nil {
-		return NoopAgent(), err
-	}
-	if agent.sqlUidCache, err = lru.New(cacheSize); err != nil {
-		return NoopAgent(), err
-	}
-	if agent.apiCache, err = lru.New(cacheSize); err != nil {
-		return NoopAgent(), err
-	}
+	agent.errorCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	agent.sqlCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	agent.sqlUidCache = newMetaCache[string, []byte](cacheSize, hashStringKey)
+	agent.apiCache = newMetaCache[apiCacheKey, int32](cacheSize, hashApiCacheKey)
 
 	config.AddReloadCallback([]string{CfgLogLevel}, logger.reloadLevel)
 	config.AddReloadCallback([]string{CfgLogOutput, CfgLogMaxSize}, logger.reloadOutput)
@@ -553,16 +543,16 @@ func (agent *agent) deleteMetaCache(md interface{}) {
 	switch md.(type) {
 	case apiMeta:
 		api := md.(apiMeta)
-		agent.apiCache.Remove(apiCacheKey{api.descriptor, api.apiType})
+		agent.apiCache.remove(apiCacheKey{api.descriptor, api.apiType})
 		break
 	case stringMeta:
-		agent.errorCache.Remove(md.(stringMeta).funcName)
+		agent.errorCache.remove(md.(stringMeta).funcName)
 		break
 	case sqlMeta:
-		agent.sqlCache.Remove(md.(sqlMeta).sql)
+		agent.sqlCache.remove(md.(sqlMeta).sql)
 		break
 	case sqlUidMeta:
-		agent.sqlUidCache.Remove(md.(sqlUidMeta).sql)
+		agent.sqlUidCache.remove(md.(sqlUidMeta).sql)
 		break
 	case exceptionMeta:
 		break
@@ -593,13 +583,13 @@ func (agent *agent) cacheError(errorName string) int32 {
 		return 0
 	}
 
-	if v, ok := agent.errorCache.Peek(errorName); ok {
-		return v.(int32)
+	if v, ok := agent.errorCache.peek(errorName); ok {
+		return v
 	}
 
 	id := atomic.AddInt32(&agent.errorIdGen, 1)
-	if v, ok, _ := agent.errorCache.PeekOrAdd(errorName, id); ok {
-		return v.(int32)
+	if v, ok := agent.errorCache.peekOrAdd(errorName, id); ok {
+		return v
 	}
 
 	md := stringMeta{
@@ -624,13 +614,13 @@ func (agent *agent) cacheSql(sql string) int32 {
 		return 0
 	}
 
-	if v, ok := agent.sqlCache.Peek(sql); ok {
-		return v.(int32)
+	if v, ok := agent.sqlCache.peek(sql); ok {
+		return v
 	}
 
 	id := atomic.AddInt32(&agent.sqlIdGen, 1)
-	if v, ok, _ := agent.sqlCache.PeekOrAdd(sql, id); ok {
-		return v.(int32)
+	if v, ok := agent.sqlCache.peekOrAdd(sql, id); ok {
+		return v
 	}
 
 	aSql := abbreviateString(sql, maxSqlSize)
@@ -649,15 +639,15 @@ func (agent *agent) cacheSqlUid(sql string) []byte {
 		return nil
 	}
 
-	if v, ok := agent.sqlUidCache.Peek(sql); ok {
-		return v.([]byte)
+	if v, ok := agent.sqlUidCache.peek(sql); ok {
+		return v
 	}
 
 	hash := murmur3.New128()
 	hash.Write([]byte(sql))
 	uid := hash.Sum(nil)
-	if v, ok, _ := agent.sqlUidCache.PeekOrAdd(sql, uid); ok {
-		return v.([]byte)
+	if v, ok := agent.sqlUidCache.peekOrAdd(sql, uid); ok {
+		return v
 	}
 
 	aSql := abbreviateString(sql, maxSqlSize)
@@ -678,13 +668,13 @@ func (agent *agent) cacheSpanApi(descriptor string, apiType int) int32 {
 
 	key := apiCacheKey{descriptor, apiType}
 
-	if v, ok := agent.apiCache.Peek(key); ok {
-		return v.(int32)
+	if v, ok := agent.apiCache.peek(key); ok {
+		return v
 	}
 
 	id := atomic.AddInt32(&agent.apiIdGen, 1)
-	if v, ok, _ := agent.apiCache.PeekOrAdd(key, id); ok {
-		return v.(int32)
+	if v, ok := agent.apiCache.peekOrAdd(key, id); ok {
+		return v
 	}
 
 	md := apiMeta{
@@ -850,10 +840,10 @@ func NewTestAgent(config *Config, t *testing.T) (Agent, error) {
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),
 		config:      config,
 	}
-	agent.errorCache, _ = lru.New(cacheSize)
-	agent.sqlCache, _ = lru.New(cacheSize)
-	agent.sqlUidCache, _ = lru.New(cacheSize)
-	agent.apiCache, _ = lru.New(cacheSize)
+	agent.errorCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	agent.sqlCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	agent.sqlUidCache = newMetaCache[string, []byte](cacheSize, hashStringKey)
+	agent.apiCache = newMetaCache[apiCacheKey, int32](cacheSize, hashApiCacheKey)
 
 	agent.agentGrpc = newMockAgentGrpc(agent, t)
 	//agent.spanGrpc = newMockSpanGrpc(agent, t)

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
-	github.com/hashicorp/golang-lru v0.5.4
 	github.com/pkg/errors v0.9.1
 	github.com/shirou/gopsutil/v3 v3.22.7
 	github.com/sirupsen/logrus v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -150,8 +150,6 @@ github.com/googleapis/google-cloud-go-testing v0.0.0-20200911160855-bcd43fbb19e8
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/meta_cache.go
+++ b/meta_cache.go
@@ -1,0 +1,152 @@
+package pinpoint
+
+import (
+	"container/list"
+	"hash/maphash"
+	"sync"
+)
+
+// metaCache replaces the four hashicorp/golang-lru metadata caches. That
+// library wraps one process-global mutex around the whole cache, and the
+// Peek/PeekOrAdd pattern used here never promoted entries, so eviction order
+// degenerated to insertion order (FIFO): a hot SQL was evicted before a
+// cold-but-recent one, re-issuing its id and re-sending its metadata to the
+// collector. This cache shards the key space (per-shard RWMutex) and restores
+// real LRU ordering with aged promotion, mirroring the C++ agent's
+// ShardedLruCache (src/cache.h): a hit only takes the write lock to splice
+// when the shard is full AND the entry has aged past half the shard capacity.
+// Promoting on every hit would serialize all hits behind the exclusive lock
+// (C++ measured 75 ns vs 1,333 ns per hot-set hit at 16 threads). Typed keys
+// also drop the interface{} boxing golang-lru forced on every lookup.
+const metaCacheShardCount = 16 // power of two; matches the C++ agent
+
+var metaCacheSeed = maphash.MakeSeed()
+
+func hashStringKey(s string) uint64 { return maphash.String(metaCacheSeed, s) }
+
+func hashApiCacheKey(k apiCacheKey) uint64 {
+	return maphash.String(metaCacheSeed, k.descriptor) ^ (uint64(k.apiType) * 0x9e3779b97f4a7c15)
+}
+
+type metaCacheEntry[K comparable, V any] struct {
+	key   K
+	value V
+	// Shard opSeq at insert / last promotion. Written under the shard's
+	// write lock, read under its read lock.
+	lastPromoted uint64
+}
+
+// metaCacheShard is padded to cacheLinePadSize for the same reason as
+// activeSpanShard in stats.go: the mutex and opSeq are the contended words,
+// and unpadded shards would ping-pong a shared line between goroutines
+// holding *different* shard locks. The payload is 64 bytes; the size
+// assertion in meta_cache_test.go fails if a field changes that.
+type metaCacheShard[K comparable, V any] struct {
+	mu           sync.RWMutex
+	m            map[K]*list.Element
+	order        *list.List // front = most recently used
+	cap          int
+	ageThreshold uint64
+	opSeq        uint64 // counts inserts and promotions; entry age = opSeq - lastPromoted
+	_            [cacheLinePadSize - 64]byte
+}
+
+type metaCache[K comparable, V any] struct {
+	hash   func(K) uint64
+	shards [metaCacheShardCount]metaCacheShard[K, V]
+}
+
+// newMetaCache splits capacity evenly across the shards, so a hot shard
+// evicts within its own slice — the same trade-off the C++ agent accepts
+// for removing the shared lock line.
+func newMetaCache[K comparable, V any](capacity int, hash func(K) uint64) *metaCache[K, V] {
+	c := &metaCache[K, V]{hash: hash}
+	perShard := capacity / metaCacheShardCount
+	if perShard < 1 {
+		perShard = 1
+	}
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.m = make(map[K]*list.Element, perShard+1)
+		s.order = list.New()
+		s.cap = perShard
+		s.ageThreshold = uint64(perShard / 2)
+		if s.ageThreshold < 1 {
+			s.ageThreshold = 1
+		}
+	}
+	return c
+}
+
+func (c *metaCache[K, V]) shard(key K) *metaCacheShard[K, V] {
+	return &c.shards[c.hash(key)&(metaCacheShardCount-1)]
+}
+
+// peek returns the cached value. A hit is normally a pure read-lock lookup;
+// only when the shard is full and the entry has aged past ageThreshold does
+// it take the write lock to move the entry to the front (aged promotion).
+func (c *metaCache[K, V]) peek(key K) (V, bool) {
+	s := c.shard(key)
+	s.mu.RLock()
+	el, ok := s.m[key]
+	if !ok {
+		s.mu.RUnlock()
+		var zero V
+		return zero, false
+	}
+	e := el.Value.(*metaCacheEntry[K, V])
+	v := e.value
+	promote := len(s.m) >= s.cap && s.opSeq-e.lastPromoted >= s.ageThreshold
+	s.mu.RUnlock()
+
+	if promote {
+		s.mu.Lock()
+		// Re-resolve: the entry may have been evicted or removed between
+		// the two locks. The value read above is still a valid answer.
+		if el, ok := s.m[key]; ok {
+			s.order.MoveToFront(el)
+			s.opSeq++
+			el.Value.(*metaCacheEntry[K, V]).lastPromoted = s.opSeq
+		}
+		s.mu.Unlock()
+	}
+	return v, true
+}
+
+// peekOrAdd inserts the value unless the key is already present, evicting the
+// least recently used entry if the shard is over capacity. It returns the
+// existing value and true when another goroutine won the insert race, so
+// callers keep a single id per key (the loser's freshly generated id is
+// discarded, same as with golang-lru's PeekOrAdd).
+func (c *metaCache[K, V]) peekOrAdd(key K, value V) (V, bool) {
+	s := c.shard(key)
+	s.mu.Lock()
+	if el, ok := s.m[key]; ok {
+		v := el.Value.(*metaCacheEntry[K, V]).value
+		s.mu.Unlock()
+		return v, true
+	}
+	s.opSeq++
+	e := &metaCacheEntry[K, V]{key: key, value: value, lastPromoted: s.opSeq}
+	s.m[key] = s.order.PushFront(e)
+	if len(s.m) > s.cap {
+		victim := s.order.Back()
+		delete(s.m, victim.Value.(*metaCacheEntry[K, V]).key)
+		s.order.Remove(victim)
+	}
+	s.mu.Unlock()
+	var zero V
+	return zero, false
+}
+
+// remove deletes the entry so the key misses next time; sendMetaWorker uses
+// this to retry metadata whose send failed.
+func (c *metaCache[K, V]) remove(key K) {
+	s := c.shard(key)
+	s.mu.Lock()
+	if el, ok := s.m[key]; ok {
+		delete(s.m, key)
+		s.order.Remove(el)
+	}
+	s.mu.Unlock()
+}

--- a/meta_cache_test.go
+++ b/meta_cache_test.go
@@ -1,0 +1,247 @@
+package pinpoint
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetaCacheShardPadding(t *testing.T) {
+	// The [cacheLinePadSize - 64]byte pad in metaCacheShard hardcodes the
+	// 64-byte payload; this breaks when a field changes that.
+	assert.Equal(t, uintptr(cacheLinePadSize), unsafe.Sizeof(metaCacheShard[string, int32]{}))
+}
+
+func TestMetaCacheBasics(t *testing.T) {
+	c := newMetaCache[string, int32](cacheSize, hashStringKey)
+
+	_, ok := c.peek("a")
+	assert.False(t, ok)
+
+	prev, ok := c.peekOrAdd("a", 1)
+	assert.False(t, ok)
+	assert.Equal(t, int32(0), prev)
+
+	v, ok := c.peek("a")
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), v)
+
+	// losing the insert race returns the existing value
+	prev, ok = c.peekOrAdd("a", 2)
+	assert.True(t, ok)
+	assert.Equal(t, int32(1), prev)
+
+	c.remove("a")
+	_, ok = c.peek("a")
+	assert.False(t, ok)
+}
+
+func TestMetaCacheEvictsLeastRecentlyUsed(t *testing.T) {
+	// capacity 16 over 16 shards = 1 entry per shard: two keys in the same
+	// shard evict each other. Find such a pair (the hash seed is random per
+	// process), then check the older key is the one that goes.
+	c := newMetaCache[string, int32](metaCacheShardCount, hashStringKey)
+	first := "key-0"
+	second := ""
+	for i := 1; i < 1000; i++ {
+		k := fmt.Sprintf("key-%d", i)
+		if c.shard(k) == c.shard(first) {
+			second = k
+			break
+		}
+	}
+	assert.NotEmpty(t, second)
+
+	c.peekOrAdd(first, 1)
+	c.peekOrAdd(second, 2)
+	_, ok := c.peek(first)
+	assert.False(t, ok)
+	v, ok := c.peek(second)
+	assert.True(t, ok)
+	assert.Equal(t, int32(2), v)
+}
+
+// fifoCache replicates how the four caches behaved on hashicorp/golang-lru:
+// Peek never promotes, so eviction order is insertion order.
+type fifoCache struct {
+	m     map[string]*list.Element
+	order *list.List
+	cap   int
+}
+
+func newFifoCache(capacity int) *fifoCache {
+	return &fifoCache{m: make(map[string]*list.Element), order: list.New(), cap: capacity}
+}
+
+func (c *fifoCache) peek(k string) bool {
+	_, ok := c.m[k]
+	return ok
+}
+
+func (c *fifoCache) add(k string) {
+	if _, ok := c.m[k]; ok {
+		return
+	}
+	c.m[k] = c.order.PushFront(k)
+	if len(c.m) > c.cap {
+		victim := c.order.Back()
+		delete(c.m, victim.Value.(string))
+		c.order.Remove(victim)
+	}
+}
+
+// runMetaWorkload interleaves a fixed hot set with a stream of one-shot churn
+// keys, the access pattern where FIFO eviction hurts: churn pushes hot keys
+// out even though they are hit every round. It returns how many times a hot
+// key had to be re-inserted after the warmup round — in the agent each such
+// re-insert is a new id plus a metadata resend to the collector.
+func runMetaWorkload(peek func(string) bool, add func(string)) int {
+	const hotN, rounds, churnPerRound = 256, 32, 256
+	hot := make([]string, hotN)
+	for i := range hot {
+		hot[i] = fmt.Sprintf("select * from hot_table_%03d where id = ?", i)
+	}
+	hotResends := 0
+	churn := 0
+	for r := 0; r < rounds; r++ {
+		for i := 0; i < hotN; i++ {
+			if !peek(hot[i]) {
+				add(hot[i])
+				if r > 0 {
+					hotResends++
+				}
+			}
+			ck := fmt.Sprintf("select * from churn_table_%06d", churn)
+			churn++
+			if !peek(ck) {
+				add(ck)
+			}
+		}
+	}
+	return hotResends
+}
+
+func TestMetaCacheLruBeatsFifoOnResends(t *testing.T) {
+	fifo := newFifoCache(cacheSize)
+	fifoResends := runMetaWorkload(fifo.peek, fifo.add)
+
+	c := newMetaCache[string, int32](cacheSize, hashStringKey)
+	lruResends := runMetaWorkload(
+		func(k string) bool { _, ok := c.peek(k); return ok },
+		func(k string) { c.peekOrAdd(k, 0) },
+	)
+
+	t.Logf("hot-key metadata resends: fifo(old)=%d lru(new)=%d", fifoResends, lruResends)
+	// observed ~11-20x fewer resends; ×4 leaves headroom for hash-seed variance
+	assert.Greater(t, fifoResends, lruResends*4)
+}
+
+func TestMetaCacheConcurrent(t *testing.T) {
+	// Small capacity keeps every shard full, so promotion, eviction, and
+	// removal all race against read-locked peeks under -race.
+	c := newMetaCache[string, int32](64, hashStringKey)
+	keys := make([]string, 512)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("key-%03d", i)
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < 20000; i++ {
+				k := keys[(i*7+g*13)&511]
+				if _, ok := c.peek(k); !ok {
+					c.peekOrAdd(k, int32(i))
+				}
+				if i&255 == 0 {
+					c.remove(k)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func TestMetaCachePeekNoAlloc(t *testing.T) {
+	c := newMetaCache[string, int32](cacheSize, hashStringKey)
+	keys := make([]string, 256)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("select * from hot_table_%03d where id = ?", i)
+		c.peekOrAdd(keys[i], int32(i))
+	}
+	i := 0
+	allocs := testing.AllocsPerRun(1000, func() {
+		c.peek(keys[i&255])
+		i++
+	})
+	assert.Equal(t, 0.0, allocs)
+}
+
+// BenchmarkMetaCacheHit measures the contended pure-hit path (cache not
+// full, so no promotion): run with -cpu=1,4,16 to see the sharding effect.
+func BenchmarkMetaCacheHit(b *testing.B) {
+	c := newMetaCache[string, int32](cacheSize, hashStringKey)
+	keys := make([]string, 512)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("select * from table_%04d where id = ? and name = ?", i)
+		c.peekOrAdd(keys[i], int32(i))
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			c.peek(keys[i&511])
+			i++
+		}
+	})
+}
+
+// BenchmarkMetaCacheMixedSaturated measures the saturated steady state: hot
+// hits with a trickle of new keys (1 in 64), so eviction and aged promotion
+// stay active throughout.
+func BenchmarkMetaCacheMixedSaturated(b *testing.B) {
+	c := newMetaCache[string, int32](cacheSize, hashStringKey)
+	hot := make([]string, 256)
+	for i := range hot {
+		hot[i] = fmt.Sprintf("select * from hot_table_%03d where id = ?", i)
+	}
+	churn := make([]string, 1<<16)
+	for i := range churn {
+		churn[i] = fmt.Sprintf("select * from churn_table_%06d", i)
+	}
+	// warmup to steady state: saturate the shards while keeping the hot set live
+	ci := 0
+	for i := 0; i < 1<<16; i++ {
+		if i&63 == 63 {
+			k := churn[ci&(1<<16-1)]
+			ci++
+			if _, ok := c.peek(k); !ok {
+				c.peekOrAdd(k, 0)
+			}
+		} else if _, ok := c.peek(hot[i&255]); !ok {
+			c.peekOrAdd(hot[i&255], 0)
+		}
+	}
+	var churnIdx int64
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if i&63 == 63 {
+				k := churn[int(atomic.AddInt64(&churnIdx, 1))&(1<<16-1)]
+				if _, ok := c.peek(k); !ok {
+					c.peekOrAdd(k, 0)
+				}
+			} else if _, ok := c.peek(hot[i&255]); !ok {
+				c.peekOrAdd(hot[i&255], 0)
+			}
+			i++
+		}
+	})
+}

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	empty "github.com/golang/protobuf/ptypes/empty"
-	lru "github.com/hashicorp/golang-lru"
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 	"github.com/pinpoint-apm/pinpoint-go-agent/protobuf/mock"
 )
@@ -31,10 +30,10 @@ func newTestAgent(config *Config) *agent {
 		},
 	}
 	a.enable.Store(true)
-	a.errorCache, _ = lru.New(cacheSize)
-	a.sqlCache, _ = lru.New(cacheSize)
-	a.sqlUidCache, _ = lru.New(cacheSize)
-	a.apiCache, _ = lru.New(cacheSize)
+	a.errorCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	a.sqlCache = newMetaCache[string, int32](cacheSize, hashStringKey)
+	a.sqlUidCache = newMetaCache[string, []byte](cacheSize, hashStringKey)
+	a.apiCache = newMetaCache[apiCacheKey, int32](cacheSize, hashApiCacheKey)
 	a.config.offGrpc = true
 
 	return a


### PR DESCRIPTION
Closes #156

## What

Replaces the four `hashicorp/golang-lru` metadata caches (API, error name, SQL, SQL UID) with an in-repo sharded LRU cache (`meta_cache.go`) and removes the `hashicorp/golang-lru` dependency — these caches were its only users.

- 16-way sharding, one `sync.RWMutex` per shard; keys hashed once with `hash/maphash`, shards padded to a cache line (same convention as `activeSpanShard` in `stats.go`).
- **Aged promotion**, mirroring the C++ agent's `ShardedLruCache`: a hit is a pure read-lock lookup unless the shard is full *and* the entry has aged past half the shard capacity — only then does it take the write lock to splice. Promoting on every hit would serialize all hits behind the exclusive lock.
- Generic typed keys/values (`string → int32`, `string → []byte`, `apiCacheKey → int32`), removing the per-lookup `interface{}` boxing; the hit path is allocation-free (asserted by `TestMetaCachePeekNoAlloc`).
- `remove` is kept so `sendMetaWorker` can still drop entries whose metadata send failed.

## Why

The old `Peek`/`PeekOrAdd` pattern never promoted entries, so eviction order degenerated to insertion order (FIFO): a hot SQL that entered early was evicted before a cold-but-recent key, and every such eviction re-issued a new id and re-sent the full metadata (SQL text up to 64 KB) to the collector. Every lookup also contended on one process-global lock per cache and boxed its key. See #156 for the full analysis.

## Results

**Eviction-induced metadata resends** (hot set of 256 keys + 256 churn keys per round × 32 rounds, capacity 1024; `TestMetaCacheLruBeatsFifoOnResends` keeps this covered):

| | FIFO (old behavior) | sharded LRU + aged promotion |
|---|---|---|
| hot-key resends | 1,792 | 89–164 (~11–20× fewer) |

**Concurrent lookup benchmarks** (Apple M-series, ns/op, before = hashicorp lru):

| | -cpu=1 | -cpu=4 | -cpu=16 |
|---|---|---|---|
| pure hit, before | 39.3 | 88.3 | 167.4 |
| pure hit, after | 24.4 | 22.3 (4.0×) | 23.2 (7.2×) |
| saturated + churn mix, before | 46.3 | 83.9 | 142.3 |
| saturated + churn mix, after | 26.4 | 30.1 (2.8×) | 41.4 (3.4×) |

The old cache degrades with core count; the new one is flat on the pure-hit path.

`go test -race -count=1 ./...` passes. No public API change; plugins are unaffected.
