### PR TITLE
[#165] Recycle span transport protobuf messages through pooled slabs

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -3,7 +3,6 @@ package pinpoint
 import (
 	"sync"
 
-	"github.com/golang/protobuf/ptypes/wrappers"
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 )
 
@@ -79,58 +78,69 @@ func (a *annotation) AppendLongIntIntByteByteString(key int32, l int64, i1 int32
 	a.append(annotationValue{key: key, typ: annotationTypeLongIntIntByteByteString, l: l, i1: i1, i2: i2, b1: b1, b2: b2, s1: s})
 }
 
-// toProto builds the protobuf annotation for a stored value. Called off the hot
-// path (sender goroutine) during serialization.
-func (v *annotationValue) toProto() *pb.PAnnotation {
-	value := &pb.PAnnotationValue{}
+// toProtoInto builds the protobuf annotation for a stored value on the
+// builder's slabs. Called off the hot path (sender goroutine) during
+// serialization; the result dies when the builder is released.
+func (v *annotationValue) toProtoInto(b *spanMessageBuilder) *pb.PAnnotation {
+	value := b.annotationValues.get()
 
 	switch v.typ {
 	case annotationTypeInt:
-		value.Field = &pb.PAnnotationValue_IntValue{IntValue: v.i1}
+		oneof := b.intOneofs.get()
+		oneof.IntValue = v.i1
+		value.Field = oneof
 	case annotationTypeLong:
-		value.Field = &pb.PAnnotationValue_LongValue{LongValue: v.l}
+		oneof := b.longOneofs.get()
+		oneof.LongValue = v.l
+		value.Field = oneof
 	case annotationTypeString:
-		value.Field = &pb.PAnnotationValue_StringValue{StringValue: v.s1}
+		oneof := b.stringOneofs.get()
+		oneof.StringValue = v.s1
+		value.Field = oneof
 	case annotationTypeStringString:
-		value.Field = &pb.PAnnotationValue_StringStringValue{
-			StringStringValue: &pb.PStringStringValue{
-				StringValue1: &wrappers.StringValue{Value: v.s1},
-				StringValue2: &wrappers.StringValue{Value: v.s2},
-			},
-		}
+		inner := b.stringStrings.get()
+		inner.StringValue1 = b.stringValue(v.s1)
+		inner.StringValue2 = b.stringValue(v.s2)
+		oneof := b.stringStringOneofs.get()
+		oneof.StringStringValue = inner
+		value.Field = oneof
 	case annotationTypeIntStringString:
-		value.Field = &pb.PAnnotationValue_IntStringStringValue{
-			IntStringStringValue: &pb.PIntStringStringValue{
-				IntValue:     v.i1,
-				StringValue1: &wrappers.StringValue{Value: v.s1},
-				StringValue2: &wrappers.StringValue{Value: v.s2},
-			},
-		}
+		inner := b.intStringStrings.get()
+		inner.IntValue = v.i1
+		inner.StringValue1 = b.stringValue(v.s1)
+		inner.StringValue2 = b.stringValue(v.s2)
+		oneof := b.intStringStringOneofs.get()
+		oneof.IntStringStringValue = inner
+		value.Field = oneof
 	case annotationTypeBytesStringString:
-		value.Field = &pb.PAnnotationValue_BytesStringStringValue{
-			BytesStringStringValue: &pb.PBytesStringStringValue{
-				BytesValue:   v.bytes,
-				StringValue1: &wrappers.StringValue{Value: v.s1},
-				StringValue2: &wrappers.StringValue{Value: v.s2},
-			},
-		}
+		inner := b.bytesStringStrings.get()
+		inner.BytesValue = v.bytes
+		inner.StringValue1 = b.stringValue(v.s1)
+		inner.StringValue2 = b.stringValue(v.s2)
+		oneof := b.bytesStringStringOneofs.get()
+		oneof.BytesStringStringValue = inner
+		value.Field = oneof
 	case annotationTypeLongIntIntByteByteString:
-		value.Field = &pb.PAnnotationValue_LongIntIntByteByteStringValue{
-			LongIntIntByteByteStringValue: &pb.PLongIntIntByteByteStringValue{
-				LongValue:   v.l,
-				IntValue1:   v.i1,
-				IntValue2:   v.i2,
-				ByteValue1:  v.b1,
-				ByteValue2:  v.b2,
-				StringValue: &wrappers.StringValue{Value: v.s1},
-			},
-		}
+		inner := b.longIntIntByteByteStrings.get()
+		inner.LongValue = v.l
+		inner.IntValue1 = v.i1
+		inner.IntValue2 = v.i2
+		inner.ByteValue1 = v.b1
+		inner.ByteValue2 = v.b2
+		inner.StringValue = b.stringValue(v.s1)
+		oneof := b.longIntIntByteByteStringOneofs.get()
+		oneof.LongIntIntByteByteStringValue = inner
+		value.Field = oneof
 	}
 
-	return &pb.PAnnotation{Key: v.key, Value: value}
+	annotation := b.annotations.get()
+	annotation.Key = v.key
+	annotation.Value = value
+	return annotation
 }
 
-func (a *annotation) getList() []*pb.PAnnotation {
+// getListInto materializes the annotation list on the builder's slabs.
+func (a *annotation) getListInto(b *spanMessageBuilder) []*pb.PAnnotation {
 	a.annotationLock.Lock()
 	defer a.annotationLock.Unlock()
 
@@ -138,9 +148,15 @@ func (a *annotation) getList() []*pb.PAnnotation {
 		return nil
 	}
 
-	list := make([]*pb.PAnnotation, len(a.values))
+	list := b.annotationLists.take(len(a.values))
 	for i := range a.values {
-		list[i] = a.values[i].toProto()
+		list[i] = a.values[i].toProtoInto(b)
 	}
 	return list
+}
+
+// getList materializes the list on a throwaway builder, so the result is
+// plainly GC-owned. Non-transport callers (JsonString) use this.
+func (a *annotation) getList() []*pb.PAnnotation {
+	return a.getListInto(&spanMessageBuilder{})
 }

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -439,7 +439,9 @@ func BenchmarkMakePSpanMessageBatch(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = makePSpanMessageBatch(batch)
+		builder := acquireSpanMessageBuilder()
+		_ = builder.makePSpanMessageBatch(batch)
+		releaseSpanMessageBuilder(builder)
 	}
 }
 

--- a/grpc.go
+++ b/grpc.go
@@ -797,17 +797,16 @@ func (s *spanStream) close() {
 }
 
 func (s *spanStream) sendSpan(chunk *spanChunk) error {
-	var gspan *pb.PSpanMessage
-
 	if s.stream == nil {
 		return status.Errorf(codes.Unavailable, "span stream is nil")
 	}
 
-	if !chunk.final || chunk.span.isAsyncSpan() {
-		gspan = makePSpanChunk(chunk)
-	} else {
-		gspan = makePSpan(chunk)
-	}
+	builder := acquireSpanMessageBuilder()
+	// Send marshals the message before it returns (also when it errors or the
+	// timeout cancels the stream), so the graph is dead once it does.
+	defer releaseSpanMessageBuilder(builder)
+
+	gspan := builder.makePSpanMessage(chunk)
 
 	if IsLogLevelEnabled(logrus.DebugLevel) {
 		Log("grpc").Debugf("PSpanMessage Size: %d", proto.Size(gspan))
@@ -863,8 +862,10 @@ func (spanGrpc *spanGrpc) collectSpanBatch(first *spanChunk, queue *spanQueue) (
 // If no permit becomes available within the flush timeout, the whole batch is skipped rather than
 // blocking the worker forever behind slow in-flight requests; completed calls always release their permit.
 func (spanGrpc *spanGrpc) sendSpanBatchAsync(chunks []*spanChunk) {
-	spanMessageBatch := makePSpanMessageBatch(chunks)
+	builder := acquireSpanMessageBuilder()
+	spanMessageBatch := builder.makePSpanMessageBatch(chunks)
 	if len(spanMessageBatch.GetSpan()) == 0 {
+		releaseSpanMessageBuilder(builder)
 		return
 	}
 
@@ -882,6 +883,7 @@ func (spanGrpc *spanGrpc) sendSpanBatchAsync(chunks []*spanChunk) {
 			len(spanGrpc.concurrentRequestPermit),
 			spanGrpc.maxConcurrentRequests,
 		)
+		releaseSpanMessageBuilder(builder)
 		return
 	}
 
@@ -889,6 +891,9 @@ func (spanGrpc *spanGrpc) sendSpanBatchAsync(chunks []*spanChunk) {
 	go func() {
 		defer spanGrpc.inFlight.Done()
 		defer spanGrpc.releaseSpanBatchPermit()
+		// The unary call marshals the request while it runs, so the batch
+		// graph is dead once SendSpanBatch returns.
+		defer releaseSpanMessageBuilder(builder)
 
 		ctx, cancel := context.WithTimeout(grpcMetadataContext(spanGrpc.agent, -1), sendStreamTimeOut)
 		defer cancel()
@@ -965,162 +970,153 @@ func handleSpanBatchResponse(response *pb.PSpanResultBatch) {
 	}
 }
 
-// makePSpanMessageBatch preserves the existing span/chunk conversion while wrapping messages for SendSpanBatch.
-// Final synchronous spans become PSpan messages; non-final chunks and async spans keep the PSpanChunk path.
-func makePSpanMessageBatch(chunks []*spanChunk) *pb.PSpanMessageBatch {
-	spanMessages := make([]*pb.PSpanMessage, 0, len(chunks))
+func (b *spanMessageBuilder) makePSpanMessageBatch(chunks []*spanChunk) *pb.PSpanMessageBatch {
+	spanMessages := b.messageLists.take(len(chunks))[:0]
 	for _, chunk := range chunks {
 		if chunk == nil || chunk.span == nil {
 			continue
 		}
-
-		if !chunk.final || chunk.span.isAsyncSpan() {
-			spanMessages = append(spanMessages, makePSpanChunk(chunk))
-		} else {
-			spanMessages = append(spanMessages, makePSpan(chunk))
-		}
+		spanMessages = append(spanMessages, b.makePSpanMessage(chunk))
 	}
 
 	return &pb.PSpanMessageBatch{Span: spanMessages}
 }
 
-func makePSpan(chunk *spanChunk) *pb.PSpanMessage {
+// makePSpanMessage converts one dequeued chunk: final synchronous spans become
+// PSpan messages; non-final chunks and async spans keep the PSpanChunk shape.
+func (b *spanMessageBuilder) makePSpanMessage(chunk *spanChunk) *pb.PSpanMessage {
+	if !chunk.final || chunk.span.isAsyncSpan() {
+		return b.makePSpanChunk(chunk)
+	}
+	return b.makePSpan(chunk)
+}
+
+func (b *spanMessageBuilder) makePSpan(chunk *spanChunk) *pb.PSpanMessage {
 	span := chunk.span
 	if span.apiId == 0 && span.operationName != "" {
 		span.annotations.AppendString(AnnotationApi, span.operationName)
 	}
 
-	spanEventList := make([]*pb.PSpanEvent, 0, len(chunk.eventChunk))
-	for _, event := range chunk.eventChunk {
-		aSpanEvent := makePSpanEvent(event)
-		spanEventList = append(spanEventList, aSpanEvent)
-	}
+	pspan := b.spans.get()
+	pspan.Version = 1
+	txId := b.txIds.get()
+	txId.AgentId = span.txId.AgentId
+	txId.AgentStartTime = span.txId.StartTime
+	txId.Sequence = span.txId.Sequence
+	pspan.TransactionId = txId
+	pspan.SpanId = span.spanId
+	pspan.ParentSpanId = span.parentSpanId
+	pspan.StartTime = span.startTime.UnixMilli()
+	pspan.Elapsed = int32(span.elapsed)
+	pspan.ServiceType = span.serviceType
 
-	gspan := &pb.PSpanMessage{
-		Field: &pb.PSpanMessage_Span{
-			Span: &pb.PSpan{
-				Version: 1,
-				TransactionId: &pb.PTransactionId{
-					AgentId:        span.txId.AgentId,
-					AgentStartTime: span.txId.StartTime,
-					Sequence:       span.txId.Sequence,
-				},
-				SpanId:       span.spanId,
-				ParentSpanId: span.parentSpanId,
-				StartTime:    span.startTime.UnixMilli(),
-				Elapsed:      int32(span.elapsed),
-				ServiceType:  span.serviceType,
-				AcceptEvent: &pb.PAcceptEvent{
-					Rpc:        span.rpcName,
-					EndPoint:   span.endPoint,
-					RemoteAddr: span.remoteAddr,
-					ParentInfo: &pb.PParentInfo{
-						ParentApplicationName: span.parentAppName,
-						ParentApplicationType: int32(span.parentAppType),
-						AcceptorHost:          span.acceptorHost,
-						ParentServiceName:     span.parentServiceName,
-					},
-				},
-				Annotation:             span.annotations.getList(),
-				ApiId:                  span.apiId,
-				Flag:                   int32(span.flags),
-				SpanEvent:              spanEventList,
-				Err:                    int32(span.err),
-				ExceptionInfo:          nil,
-				ApplicationServiceType: span.agent.appType,
-				LoggingTransactionInfo: span.loggingInfo,
-			},
-		},
-	}
+	acceptEvent := b.acceptEvents.get()
+	acceptEvent.Rpc = span.rpcName
+	acceptEvent.EndPoint = span.endPoint
+	acceptEvent.RemoteAddr = span.remoteAddr
+	parentInfo := b.parentInfos.get()
+	parentInfo.ParentApplicationName = span.parentAppName
+	parentInfo.ParentApplicationType = int32(span.parentAppType)
+	parentInfo.AcceptorHost = span.acceptorHost
+	parentInfo.ParentServiceName = span.parentServiceName
+	acceptEvent.ParentInfo = parentInfo
+	pspan.AcceptEvent = acceptEvent
+
+	pspan.Annotation = span.annotations.getListInto(b)
+	pspan.ApiId = span.apiId
+	pspan.Flag = int32(span.flags)
+	pspan.SpanEvent = b.makePSpanEventList(chunk)
+	pspan.Err = int32(span.err)
+	pspan.ApplicationServiceType = span.agent.appType
+	pspan.LoggingTransactionInfo = span.loggingInfo
 
 	if span.errorString != "" {
-		gspan.GetSpan().ExceptionInfo = &pb.PIntStringValue{
-			IntValue:    span.errorFuncId,
-			StringValue: &wrappers.StringValue{Value: span.errorString},
-		}
+		exceptionInfo := b.intStringValues.get()
+		exceptionInfo.IntValue = span.errorFuncId
+		exceptionInfo.StringValue = b.stringValue(span.errorString)
+		pspan.ExceptionInfo = exceptionInfo
 	}
 
+	oneof := b.spanOneofs.get()
+	oneof.Span = pspan
+	gspan := b.messages.get()
+	gspan.Field = oneof
 	return gspan
 }
 
-func makePSpanChunk(chunk *spanChunk) *pb.PSpanMessage {
+func (b *spanMessageBuilder) makePSpanChunk(chunk *spanChunk) *pb.PSpanMessage {
 	span := chunk.span
 
-	spanEventList := make([]*pb.PSpanEvent, 0, len(chunk.eventChunk))
-	for _, event := range chunk.eventChunk {
-		aSpanEvent := makePSpanEvent(event)
-		spanEventList = append(spanEventList, aSpanEvent)
-	}
-
-	gspan := &pb.PSpanMessage{
-		Field: &pb.PSpanMessage_SpanChunk{
-			SpanChunk: &pb.PSpanChunk{
-				Version: 1,
-				TransactionId: &pb.PTransactionId{
-					AgentId:        span.txId.AgentId,
-					AgentStartTime: span.txId.StartTime,
-					Sequence:       span.txId.Sequence,
-				},
-				SpanId:                 span.spanId,
-				KeyTime:                chunk.keyTime,
-				EndPoint:               span.endPoint,
-				SpanEvent:              spanEventList,
-				ApplicationServiceType: span.agent.appType,
-				LocalAsyncId:           nil,
-			},
-		},
-	}
+	pchunk := b.chunks.get()
+	pchunk.Version = 1
+	txId := b.txIds.get()
+	txId.AgentId = span.txId.AgentId
+	txId.AgentStartTime = span.txId.StartTime
+	txId.Sequence = span.txId.Sequence
+	pchunk.TransactionId = txId
+	pchunk.SpanId = span.spanId
+	pchunk.KeyTime = chunk.keyTime
+	pchunk.EndPoint = span.endPoint
+	pchunk.SpanEvent = b.makePSpanEventList(chunk)
+	pchunk.ApplicationServiceType = span.agent.appType
 
 	if span.isAsyncSpan() {
-		gspan.GetSpanChunk().LocalAsyncId = &pb.PLocalAsyncId{
-			AsyncId:  span.asyncId,
-			Sequence: span.asyncSequence,
-		}
+		localAsyncId := b.localAsyncIds.get()
+		localAsyncId.AsyncId = span.asyncId
+		localAsyncId.Sequence = span.asyncSequence
+		pchunk.LocalAsyncId = localAsyncId
 	}
 
+	oneof := b.chunkOneofs.get()
+	oneof.SpanChunk = pchunk
+	gspan := b.messages.get()
+	gspan.Field = oneof
 	return gspan
 }
 
-func makePSpanEvent(event *spanEvent) *pb.PSpanEvent {
+func (b *spanMessageBuilder) makePSpanEventList(chunk *spanChunk) []*pb.PSpanEvent {
+	spanEventList := b.eventLists.take(len(chunk.eventChunk))
+	for i, event := range chunk.eventChunk {
+		spanEventList[i] = b.makePSpanEvent(event)
+	}
+	return spanEventList
+}
+
+func (b *spanMessageBuilder) makePSpanEvent(event *spanEvent) *pb.PSpanEvent {
 	if event.apiId == 0 && event.operationName != "" {
 		event.annotations.AppendString(AnnotationApi, event.operationName)
 	}
 
-	aSpanEvent := pb.PSpanEvent{
-		Sequence:      event.sequence,
-		Depth:         event.depth,
-		StartElapsed:  int32(event.startElapsed),
-		EndElapsed:    int32(event.endElapsed),
-		ServiceType:   event.serviceType,
-		Annotation:    event.annotations.getList(),
-		ApiId:         event.apiId,
-		ExceptionInfo: nil,
-		NextEvent:     nil,
-		AsyncEvent:    event.asyncId,
-	}
+	aSpanEvent := b.events.get()
+	aSpanEvent.Sequence = event.sequence
+	aSpanEvent.Depth = event.depth
+	aSpanEvent.StartElapsed = int32(event.startElapsed)
+	aSpanEvent.EndElapsed = int32(event.endElapsed)
+	aSpanEvent.ServiceType = event.serviceType
+	aSpanEvent.Annotation = event.annotations.getListInto(b)
+	aSpanEvent.ApiId = event.apiId
+	aSpanEvent.AsyncEvent = event.asyncId
 
 	if event.errorString != "" {
-		aSpanEvent.ExceptionInfo = &pb.PIntStringValue{
-			IntValue:    event.errorFuncId,
-			StringValue: &wrappers.StringValue{Value: event.errorString},
-		}
+		exceptionInfo := b.intStringValues.get()
+		exceptionInfo.IntValue = event.errorFuncId
+		exceptionInfo.StringValue = b.stringValue(event.errorString)
+		aSpanEvent.ExceptionInfo = exceptionInfo
 	}
 
 	if event.destinationId != "" {
-		next := &pb.PNextEvent{
-			Field: &pb.PNextEvent_MessageEvent{
-				MessageEvent: &pb.PMessageEvent{
-					NextSpanId:    event.nextSpanId,
-					EndPoint:      event.endPoint,
-					DestinationId: event.destinationId,
-				},
-			},
-		}
-
+		messageEvent := b.messageEvents.get()
+		messageEvent.NextSpanId = event.nextSpanId
+		messageEvent.EndPoint = event.endPoint
+		messageEvent.DestinationId = event.destinationId
+		oneof := b.nextEventOneofs.get()
+		oneof.MessageEvent = messageEvent
+		next := b.nextEvents.get()
+		next.Field = oneof
 		aSpanEvent.NextEvent = next
 	}
 
-	return &aSpanEvent
+	return aSpanEvent
 }
 
 type statClient interface {

--- a/grpc.go
+++ b/grpc.go
@@ -802,8 +802,6 @@ func (s *spanStream) sendSpan(chunk *spanChunk) error {
 	}
 
 	builder := acquireSpanMessageBuilder()
-	// Send marshals the message before it returns (also when it errors or the
-	// timeout cancels the stream), so the graph is dead once it does.
 	defer releaseSpanMessageBuilder(builder)
 
 	gspan := builder.makePSpanMessage(chunk)
@@ -813,6 +811,10 @@ func (s *spanStream) sendSpan(chunk *spanChunk) error {
 	}
 	if IsLogLevelEnabled(logrus.TraceLevel) {
 		Log("grpc").Tracef("PSpanMessage: %s", gspan.String())
+	}
+	if grpc.EnableTracing {
+		// grpc-go's lazy trace keeps the request after Send returns.
+		gspan = proto.Clone(gspan).(*pb.PSpanMessage)
 	}
 
 	err := sendStreamWithTimeout(func() error { return s.stream.Send(gspan) }, s.cancel, sendStreamTimeOut, "span stream.Send()")
@@ -886,13 +888,15 @@ func (spanGrpc *spanGrpc) sendSpanBatchAsync(chunks []*spanChunk) {
 		releaseSpanMessageBuilder(builder)
 		return
 	}
+	if grpc.EnableTracing {
+		// Completed unary traces can also retain their request.
+		spanMessageBatch = proto.Clone(spanMessageBatch).(*pb.PSpanMessageBatch)
+	}
 
 	spanGrpc.inFlight.Add(1)
 	go func() {
 		defer spanGrpc.inFlight.Done()
 		defer spanGrpc.releaseSpanBatchPermit()
-		// The unary call marshals the request while it runs, so the batch
-		// graph is dead once SendSpanBatch returns.
 		defer releaseSpanMessageBuilder(builder)
 
 		ctx, cancel := context.WithTimeout(grpcMetadataContext(spanGrpc.agent, -1), sendStreamTimeOut)

--- a/grpc_bench_test.go
+++ b/grpc_bench_test.go
@@ -1,0 +1,204 @@
+package pinpoint
+
+// Span transport conversion benchmarks.
+//
+// These measure the sender-side protobuf work that runs once per span send:
+// building the PSpanMessage object graph (makePSpan / makePSpanChunk /
+// makePSpanMessageBatch) and, for scale, the wire serialization gRPC performs
+// on top of it. They quantify the per-send allocation cost the report's §2.9
+// attributes to "a fresh protobuf struct per send".
+//
+// Run:
+//
+//	go test -run=^$ -bench=Benchmark_spanTransport -benchmem
+//	go test -run=^$ -bench=Benchmark_spanTransport -benchmem -memprofile=alloc.out
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	empty "github.com/golang/protobuf/ptypes/empty"
+	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+)
+
+// buildBenchChunk builds a finished, realistic span chunk: a sampled web
+// request with nEvents traced calls, each carrying one SQL-shaped annotation,
+// plus an HTTP status annotation on the span itself. The chunk is what
+// sendSpanWorker dequeues and hands to the conversion functions.
+func buildBenchChunk(a *agent, nEvents int) *spanChunk {
+	s := newSampledSpan(a, "GET /bench", "/bench/rpc")
+	s.annotations.AppendInt(AnnotationHttpStatusCode, 200)
+	s.endPoint = "localhost:8080"
+	s.remoteAddr = "10.0.0.1"
+
+	for i := 0; i < nEvents; i++ {
+		se := newSpanEvent(s, "example.com/pkg.query")
+		se.annotations.AppendIntStringString(AnnotationSqlUid, 1,
+			"SELECT id, name, email FROM users WHERE id = ?", "42")
+		se.endElapsed = 1
+		s.eventDepth++ // keep depths distinct, as real nesting would
+		s.eventSequence++
+		s.spanEvents = append(s.spanEvents, se)
+	}
+
+	chunk := s.newEventChunk(true)
+	chunk.optimizeSpanEvents()
+	return chunk
+}
+
+// Conversion only: the object graph built for every stream Send.
+func Benchmark_spanTransport_makePSpan(b *testing.B) {
+	a := benchAgent()
+	chunk := buildBenchChunk(a, 10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := acquireSpanMessageBuilder()
+		_ = builder.makePSpan(chunk)
+		releaseSpanMessageBuilder(builder)
+	}
+}
+
+// Conversion + wire marshal: the full protobuf cost of one stream Send.
+func Benchmark_spanTransport_makePSpanMarshal(b *testing.B) {
+	a := benchAgent()
+	chunk := buildBenchChunk(a, 10)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := acquireSpanMessageBuilder()
+		msg := builder.makePSpan(chunk)
+		if _, err := proto.Marshal(msg); err != nil {
+			b.Fatal(err)
+		}
+		releaseSpanMessageBuilder(builder)
+	}
+}
+
+// The batch path: one SendSpanBatch request at the default batch size.
+func Benchmark_spanTransport_makePSpanMessageBatch(b *testing.B) {
+	a := benchAgent()
+	chunks := make([]*spanChunk, defaultSpanBatchSize)
+	for i := range chunks {
+		chunks[i] = buildBenchChunk(a, 10)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := acquireSpanMessageBuilder()
+		_ = builder.makePSpanMessageBatch(chunks)
+		releaseSpanMessageBuilder(builder)
+	}
+}
+
+func Benchmark_spanTransport_makePSpanMessageBatchMarshal(b *testing.B) {
+	a := benchAgent()
+	chunks := make([]*spanChunk, defaultSpanBatchSize)
+	for i := range chunks {
+		chunks[i] = buildBenchChunk(a, 10)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := acquireSpanMessageBuilder()
+		msg := builder.makePSpanMessageBatch(chunks)
+		if _, err := proto.Marshal(msg); err != nil {
+			b.Fatal(err)
+		}
+		releaseSpanMessageBuilder(builder)
+	}
+}
+
+// Event-count scaling: where the per-send allocations come from.
+func Benchmark_spanTransport_makePSpanEvents1(b *testing.B)  { benchMakePSpanN(b, 1) }
+func Benchmark_spanTransport_makePSpanEvents50(b *testing.B) { benchMakePSpanN(b, 50) }
+
+func benchMakePSpanN(b *testing.B, nEvents int) {
+	a := benchAgent()
+	chunk := buildBenchChunk(a, nEvents)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		builder := acquireSpanMessageBuilder()
+		_ = builder.makePSpan(chunk)
+		releaseSpanMessageBuilder(builder)
+	}
+}
+
+// --- stream vs batch, agent-side cost over a stub transport ---
+//
+// The stubs perform the wire marshal a real grpc-go Send / unary call does,
+// but no network I/O, so the numbers compare the two transports' agent-side
+// machinery: per-span timer + marshal on the stream path vs per-batch
+// goroutine + permit + context on the batch path.
+
+type stubSpanSendClient struct {
+	grpc.ClientStream
+}
+
+func (s *stubSpanSendClient) Send(msg *pb.PSpanMessage) error {
+	_, err := proto.Marshal(msg)
+	return err
+}
+
+func (s *stubSpanSendClient) CloseAndRecv() (*empty.Empty, error) { return &empty.Empty{}, nil }
+
+type stubSpanBatchClient struct{}
+
+func (stubSpanBatchClient) SendSpan(ctx context.Context) (pb.Span_SendSpanClient, error) {
+	panic("not used")
+}
+
+func (stubSpanBatchClient) SendSpanBatch(ctx context.Context, in *pb.PSpanMessageBatch) (*pb.PSpanResultBatch, error) {
+	_, err := proto.Marshal(in)
+	return &pb.PSpanResultBatch{}, err
+}
+
+func Benchmark_spanTransport_streamSendPerSpan(b *testing.B) {
+	a := benchAgent()
+	chunk := buildBenchChunk(a, 10)
+	stream := &spanStream{stream: &stubSpanSendClient{}, cancel: func() {}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := stream.sendSpan(chunk); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// One iteration sends one 50-span batch; divide ns/op, B/op, allocs/op by 50
+// for the per-span cost.
+func Benchmark_spanTransport_batchSendPerBatch50(b *testing.B) {
+	a := benchAgent()
+	spanGrpc := &spanGrpc{
+		spanClient:              stubSpanBatchClient{},
+		agent:                   a,
+		batchSize:               defaultSpanBatchSize,
+		batchFlushTimeout:       time.Second,
+		batchCollectDeadline:    time.Duration(defaultSpanBatchCollectDeadline) * time.Millisecond,
+		maxConcurrentRequests:   8,
+		concurrentRequestPermit: make(chan struct{}, 8),
+	}
+	chunks := make([]*spanChunk, defaultSpanBatchSize)
+	for i := range chunks {
+		chunks[i] = buildBenchChunk(a, 10)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		spanGrpc.sendSpanBatchAsync(chunks)
+	}
+	b.StopTimer()
+	spanGrpc.inFlight.Wait()
+}

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -12,6 +12,7 @@ import (
 	lru "github.com/hashicorp/golang-lru"
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 	"github.com/pinpoint-apm/pinpoint-go-agent/protobuf/mock"
+	"google.golang.org/protobuf/proto"
 )
 
 func newTestAgent(config *Config) *agent {
@@ -130,8 +131,11 @@ func (spanGrpcClient *mockSpanGrpcClient) SendSpan(ctx context.Context) (pb.Span
 }
 
 func (spanGrpcClient *mockSpanGrpcClient) SendSpanBatch(ctx context.Context, in *pb.PSpanMessageBatch) (*pb.PSpanResultBatch, error) {
+	// Clone like the real transport, which marshals the request during the
+	// call: the sender recycles the message once SendSpanBatch returns, so a
+	// retained pointer would later observe recycled memory.
 	spanGrpcClient.mu.Lock()
-	spanGrpcClient.requests = append(spanGrpcClient.requests, in)
+	spanGrpcClient.requests = append(spanGrpcClient.requests, proto.Clone(in).(*pb.PSpanMessageBatch))
 	spanGrpcClient.mu.Unlock()
 
 	if spanGrpcClient.response != nil || spanGrpcClient.err != nil {

--- a/span_slab.go
+++ b/span_slab.go
@@ -1,0 +1,154 @@
+package pinpoint
+
+import (
+	"sync"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
+)
+
+// slab hands out pointers to zeroed T values carved from one reusable backing
+// array, so a protobuf message graph costs one allocation per node type at
+// steady state instead of one per node. Growth mid-build is safe: append
+// initializes the new slot before its pointer is taken, and pointers handed
+// out earlier keep referencing the orphaned old array, which stays valid.
+type slab[T any] struct{ buf []T }
+
+func (s *slab[T]) get() *T {
+	var zero T
+	s.buf = append(s.buf, zero)
+	return &s.buf[len(s.buf)-1]
+}
+
+// reset recycles every value handed out since the last reset. The clear drops
+// references (strings, sub-messages) the recycled values still hold, so a
+// builder idling in the pool does not retain the last send's data.
+func (s *slab[T]) reset() {
+	clear(s.buf)
+	s.buf = s.buf[:0]
+}
+
+// ptrSlab hands out fixed-size []*T lists carved from one reusable backing
+// array. The returned slice is capped at n, zeroed, and owned by the caller
+// until the next reset.
+type ptrSlab[T any] struct{ buf []*T }
+
+func (s *ptrSlab[T]) take(n int) []*T {
+	if n == 0 {
+		return nil
+	}
+	if len(s.buf)+n > cap(s.buf) {
+		s.buf = make([]*T, 0, max(2*cap(s.buf), n, 32))
+	}
+	start := len(s.buf)
+	s.buf = s.buf[:start+n]
+	sub := s.buf[start : start+n : start+n]
+	clear(sub)
+	return sub
+}
+
+func (s *ptrSlab[T]) reset() {
+	clear(s.buf)
+	s.buf = s.buf[:0]
+}
+
+// spanMessageBuilder builds PSpanMessage graphs out of reusable slabs — the Go
+// stand-in for the C++ agent's per-call protobuf Arena (grpc.cpp SendSpanBatch:
+// build on the arena, send, arena_.Reset()).
+//
+// Ownership: every message a build method returns lives on the builder's slabs
+// and dies at releaseSpanMessageBuilder. Release strictly after the collector
+// send completes: stream.Send marshals synchronously before returning, and a
+// unary SendSpanBatch call marshals during the call, so "after Send / the call
+// returns" is the reuse boundary. Releasing earlier recycles memory a send
+// still references and mixes data between spans.
+type spanMessageBuilder struct {
+	messages      slab[pb.PSpanMessage]
+	spanOneofs    slab[pb.PSpanMessage_Span]
+	spans         slab[pb.PSpan]
+	chunkOneofs   slab[pb.PSpanMessage_SpanChunk]
+	chunks        slab[pb.PSpanChunk]
+	txIds         slab[pb.PTransactionId]
+	acceptEvents  slab[pb.PAcceptEvent]
+	parentInfos   slab[pb.PParentInfo]
+	localAsyncIds slab[pb.PLocalAsyncId]
+
+	events          slab[pb.PSpanEvent]
+	eventLists      ptrSlab[pb.PSpanEvent]
+	messageLists    ptrSlab[pb.PSpanMessage]
+	nextEvents      slab[pb.PNextEvent]
+	nextEventOneofs slab[pb.PNextEvent_MessageEvent]
+	messageEvents   slab[pb.PMessageEvent]
+	intStringValues slab[pb.PIntStringValue]
+	stringValues    slab[wrappers.StringValue]
+
+	annotations                    slab[pb.PAnnotation]
+	annotationLists                ptrSlab[pb.PAnnotation]
+	annotationValues               slab[pb.PAnnotationValue]
+	intOneofs                      slab[pb.PAnnotationValue_IntValue]
+	longOneofs                     slab[pb.PAnnotationValue_LongValue]
+	stringOneofs                   slab[pb.PAnnotationValue_StringValue]
+	stringStringOneofs             slab[pb.PAnnotationValue_StringStringValue]
+	stringStrings                  slab[pb.PStringStringValue]
+	intStringStringOneofs          slab[pb.PAnnotationValue_IntStringStringValue]
+	intStringStrings               slab[pb.PIntStringStringValue]
+	bytesStringStringOneofs        slab[pb.PAnnotationValue_BytesStringStringValue]
+	bytesStringStrings             slab[pb.PBytesStringStringValue]
+	longIntIntByteByteStringOneofs slab[pb.PAnnotationValue_LongIntIntByteByteStringValue]
+	longIntIntByteByteStrings      slab[pb.PLongIntIntByteByteStringValue]
+}
+
+func (b *spanMessageBuilder) reset() {
+	b.messages.reset()
+	b.spanOneofs.reset()
+	b.spans.reset()
+	b.chunkOneofs.reset()
+	b.chunks.reset()
+	b.txIds.reset()
+	b.acceptEvents.reset()
+	b.parentInfos.reset()
+	b.localAsyncIds.reset()
+
+	b.events.reset()
+	b.eventLists.reset()
+	b.messageLists.reset()
+	b.nextEvents.reset()
+	b.nextEventOneofs.reset()
+	b.messageEvents.reset()
+	b.intStringValues.reset()
+	b.stringValues.reset()
+
+	b.annotations.reset()
+	b.annotationLists.reset()
+	b.annotationValues.reset()
+	b.intOneofs.reset()
+	b.longOneofs.reset()
+	b.stringOneofs.reset()
+	b.stringStringOneofs.reset()
+	b.stringStrings.reset()
+	b.intStringStringOneofs.reset()
+	b.intStringStrings.reset()
+	b.bytesStringStringOneofs.reset()
+	b.bytesStringStrings.reset()
+	b.longIntIntByteByteStringOneofs.reset()
+	b.longIntIntByteByteStrings.reset()
+}
+
+func (b *spanMessageBuilder) stringValue(s string) *wrappers.StringValue {
+	v := b.stringValues.get()
+	v.Value = s
+	return v
+}
+
+var spanMessageBuilderPool = sync.Pool{New: func() any { return &spanMessageBuilder{} }}
+
+func acquireSpanMessageBuilder() *spanMessageBuilder {
+	return spanMessageBuilderPool.Get().(*spanMessageBuilder)
+}
+
+// releaseSpanMessageBuilder recycles every message the builder produced.
+// Call only after the collector send completed (see the type comment).
+func releaseSpanMessageBuilder(b *spanMessageBuilder) {
+	b.reset()
+	spanMessageBuilderPool.Put(b)
+}

--- a/span_slab.go
+++ b/span_slab.go
@@ -60,8 +60,9 @@ func (s *ptrSlab[T]) reset() {
 // and dies at releaseSpanMessageBuilder. Release strictly after the collector
 // send completes: stream.Send marshals synchronously before returning, and a
 // unary SendSpanBatch call marshals during the call, so "after Send / the call
-// returns" is the reuse boundary. Releasing earlier recycles memory a send
-// still references and mixes data between spans.
+// returns" is the normal reuse boundary. grpc-go tracing retains requests
+// beyond that boundary, so senders pass it a GC-owned clone instead. Releasing
+// earlier recycles memory a send still references and mixes data between spans.
 type spanMessageBuilder struct {
 	messages      slab[pb.PSpanMessage]
 	spanOneofs    slab[pb.PSpanMessage_Span]

--- a/span_slab_test.go
+++ b/span_slab_test.go
@@ -1,0 +1,240 @@
+package pinpoint
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+)
+
+// slabTestChunk builds a final span chunk whose every field is derived from
+// seed, so a message that mixes data from two sends is detectable.
+func slabTestChunk(a *agent, seed int, nEvents int) *spanChunk {
+	s := newSampledSpan(a, fmt.Sprintf("op-%d", seed), fmt.Sprintf("/rpc/%d", seed))
+	s.spanId = int64(seed)
+	s.endPoint = fmt.Sprintf("ep-%d", seed)
+	s.annotations.AppendString(AnnotationApi, fmt.Sprintf("v-%d", seed))
+
+	for i := 0; i < nEvents; i++ {
+		se := newSpanEvent(s, fmt.Sprintf("event-%d", seed))
+		se.annotations.AppendStringString(AnnotationApi, fmt.Sprintf("e-%d", seed), fmt.Sprintf("e2-%d", seed))
+		se.endElapsed = 1
+		s.eventSequence++
+		s.spanEvents = append(s.spanEvents, se)
+	}
+
+	chunk := s.newEventChunk(true)
+	chunk.optimizeSpanEvents()
+	return chunk
+}
+
+// verifySeedMessage checks that every seed-derived field of one PSpan message
+// carries the same seed.
+func verifySeedMessage(msg *pb.PSpanMessage, seed int, nEvents int) error {
+	span := msg.GetSpan()
+	if span == nil {
+		return fmt.Errorf("seed %d: message is not a PSpan", seed)
+	}
+	if span.GetSpanId() != int64(seed) {
+		return fmt.Errorf("seed %d: spanId %d", seed, span.GetSpanId())
+	}
+	if want := fmt.Sprintf("/rpc/%d", seed); span.GetAcceptEvent().GetRpc() != want {
+		return fmt.Errorf("seed %d: rpc %q", seed, span.GetAcceptEvent().GetRpc())
+	}
+	if want := fmt.Sprintf("ep-%d", seed); span.GetAcceptEvent().GetEndPoint() != want {
+		return fmt.Errorf("seed %d: endPoint %q", seed, span.GetAcceptEvent().GetEndPoint())
+	}
+	if got := span.GetAnnotation()[0].GetValue().GetStringValue(); got != fmt.Sprintf("v-%d", seed) {
+		return fmt.Errorf("seed %d: span annotation %q", seed, got)
+	}
+	if len(span.GetSpanEvent()) != nEvents {
+		return fmt.Errorf("seed %d: %d events", seed, len(span.GetSpanEvent()))
+	}
+	for _, ev := range span.GetSpanEvent() {
+		ss := ev.GetAnnotation()[0].GetValue().GetStringStringValue()
+		if ss.GetStringValue1().GetValue() != fmt.Sprintf("e-%d", seed) ||
+			ss.GetStringValue2().GetValue() != fmt.Sprintf("e2-%d", seed) {
+			return fmt.Errorf("seed %d: event annotation %q/%q",
+				seed, ss.GetStringValue1().GetValue(), ss.GetStringValue2().GetValue())
+		}
+	}
+	return nil
+}
+
+// A reused builder must produce the same message a fresh one does — a reset
+// that leaks state between sends would show up as a diff.
+func Test_spanMessageBuilder_reuseMatchesFresh(t *testing.T) {
+	a := newTestAgent(defaultConfig())
+	chunk := slabTestChunk(a, 7, 3)
+
+	fresh := (&spanMessageBuilder{}).makePSpan(chunk)
+
+	reused := &spanMessageBuilder{}
+	for seed := 0; seed < 5; seed++ {
+		other := slabTestChunk(a, 100+seed, 5)
+		reused.makePSpan(other)
+		reused.reset()
+	}
+	got := reused.makePSpan(chunk)
+
+	assert.True(t, proto.Equal(fresh, got), "reused builder diverged:\nfresh: %s\ngot:   %s", fresh, got)
+	assert.NoError(t, verifySeedMessage(got, 7, 3))
+}
+
+// Error info, next event, and the async-chunk shape ride the less-traveled
+// slab paths; make sure they materialize with the right content.
+func Test_spanMessageBuilder_errorNextEventAndAsyncChunk(t *testing.T) {
+	a := newTestAgent(defaultConfig())
+
+	s := newSampledSpan(a, "op", "/rpc")
+	s.errorString = "span failed"
+	s.errorFuncId = 11
+	se := newSpanEvent(s, "client-call")
+	se.errorString = "event failed"
+	se.errorFuncId = 22
+	se.destinationId = "db-1"
+	se.nextSpanId = 999
+	se.endPoint = "db-host:3306"
+	s.spanEvents = append(s.spanEvents, se)
+	chunk := s.newEventChunk(true)
+	chunk.optimizeSpanEvents()
+
+	builder := acquireSpanMessageBuilder()
+	defer releaseSpanMessageBuilder(builder)
+
+	span := builder.makePSpanMessage(chunk).GetSpan()
+	assert.Equal(t, "span failed", span.GetExceptionInfo().GetStringValue().GetValue())
+	assert.Equal(t, int32(11), span.GetExceptionInfo().GetIntValue())
+	ev := span.GetSpanEvent()[0]
+	assert.Equal(t, "event failed", ev.GetExceptionInfo().GetStringValue().GetValue())
+	assert.Equal(t, int32(22), ev.GetExceptionInfo().GetIntValue())
+	me := ev.GetNextEvent().GetMessageEvent()
+	assert.Equal(t, int64(999), me.GetNextSpanId())
+	assert.Equal(t, "db-1", me.GetDestinationId())
+	assert.Equal(t, "db-host:3306", me.GetEndPoint())
+
+	async := defaultSpan(a)
+	async.asyncId = 5
+	async.asyncSequence = 2
+	async.spanEvents = append(async.spanEvents, newSpanEvent(async, "async-op"))
+	asyncChunk := async.newEventChunk(false)
+	asyncChunk.optimizeSpanEvents()
+	pchunk := builder.makePSpanMessage(asyncChunk).GetSpanChunk()
+	if assert.NotNil(t, pchunk, "async span must keep the PSpanChunk shape") {
+		assert.Equal(t, int32(5), pchunk.GetLocalAsyncId().GetAsyncId())
+		assert.Equal(t, int32(2), pchunk.GetLocalAsyncId().GetSequence())
+	}
+}
+
+// The stream sender's contract: the message is marshaled by Send before the
+// builder is released. Bytes captured at "Send" time must stay intact after
+// the builder is recycled for later spans.
+func Test_spanMessageBuilder_streamReuseKeepsSentBytes(t *testing.T) {
+	a := newTestAgent(defaultConfig())
+
+	type sent struct {
+		seed  int
+		bytes []byte
+	}
+	var sends []sent
+
+	for seed := 1; seed <= 20; seed++ {
+		builder := acquireSpanMessageBuilder()
+		msg := builder.makePSpanMessage(slabTestChunk(a, seed, 4))
+		wire, err := proto.Marshal(msg) // what stream.Send does before returning
+		assert.NoError(t, err)
+		sends = append(sends, sent{seed, wire})
+		releaseSpanMessageBuilder(builder)
+	}
+
+	for _, s := range sends {
+		var msg pb.PSpanMessage
+		assert.NoError(t, proto.Unmarshal(s.bytes, &msg))
+		assert.NoError(t, verifySeedMessage(&msg, s.seed, 4))
+	}
+}
+
+// mixCheckSpanClient verifies every batch at call time — while the sender
+// still owns the builder — and holds the call briefly so many builders stay
+// in flight at once.
+type mixCheckSpanClient struct {
+	mu       sync.Mutex
+	errs     []error
+	received int
+}
+
+func (c *mixCheckSpanClient) SendSpan(ctx context.Context) (pb.Span_SendSpanClient, error) {
+	panic("not used")
+}
+
+func (c *mixCheckSpanClient) SendSpanBatch(ctx context.Context, in *pb.PSpanMessageBatch) (*pb.PSpanResultBatch, error) {
+	time.Sleep(time.Millisecond)
+	for _, msg := range in.GetSpan() {
+		rpc := msg.GetSpan().GetAcceptEvent().GetRpc()
+		var seed int
+		if _, err := fmt.Sscanf(rpc, "/rpc/%d", &seed); err != nil {
+			seed = -1
+		}
+		err := verifySeedMessage(msg, seed, 4)
+		c.mu.Lock()
+		if err != nil {
+			c.errs = append(c.errs, err)
+		}
+		c.received++
+		c.mu.Unlock()
+	}
+	return &pb.PSpanResultBatch{}, nil
+}
+
+// Concurrent batch sends must never observe another send's data through a
+// recycled builder. Run with -race.
+func Test_spanGrpc_sendSpanBatchAsync_noDataMixing(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	client := &mixCheckSpanClient{}
+	spanGrpc := &spanGrpc{
+		spanClient:              client,
+		agent:                   agent,
+		batchSize:               defaultSpanBatchSize,
+		batchFlushTimeout:       time.Second,
+		batchCollectDeadline:    time.Duration(defaultSpanBatchCollectDeadline) * time.Millisecond,
+		maxConcurrentRequests:   8,
+		concurrentRequestPermit: make(chan struct{}, 8),
+	}
+
+	const senders, batchesPerSender, spansPerBatch = 4, 25, 5
+	var wg sync.WaitGroup
+	for g := 0; g < senders; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < batchesPerSender; i++ {
+				chunks := make([]*spanChunk, spansPerBatch)
+				for j := range chunks {
+					seed := (g*batchesPerSender+i)*spansPerBatch + j
+					chunks[j] = slabTestChunk(agent, seed, 4)
+				}
+				spanGrpc.sendSpanBatchAsync(chunks)
+			}
+		}(g)
+	}
+	wg.Wait()
+	spanGrpc.inFlight.Wait()
+
+	client.mu.Lock()
+	defer client.mu.Unlock()
+	if len(client.errs) > 0 {
+		msgs := make([]string, 0, len(client.errs))
+		for _, err := range client.errs {
+			msgs = append(msgs, err.Error())
+		}
+		t.Fatalf("mixed span data:\n%s", strings.Join(msgs, "\n"))
+	}
+	assert.Equal(t, senders*batchesPerSender*spansPerBatch, client.received,
+		"every span must reach the collector (no permit timeouts expected)")
+}

--- a/span_slab_test.go
+++ b/span_slab_test.go
@@ -10,6 +10,7 @@ import (
 
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -157,6 +158,57 @@ func Test_spanMessageBuilder_streamReuseKeepsSentBytes(t *testing.T) {
 		var msg pb.PSpanMessage
 		assert.NoError(t, proto.Unmarshal(s.bytes, &msg))
 		assert.NoError(t, verifySeedMessage(&msg, s.seed, 4))
+	}
+}
+
+type retainingSpanSendClient struct {
+	pb.Span_SendSpanClient
+	request *pb.PSpanMessage
+}
+
+func (c *retainingSpanSendClient) Send(in *pb.PSpanMessage) error {
+	c.request = in
+	return nil
+}
+
+type retainingSpanBatchClient struct {
+	request *pb.PSpanMessageBatch
+}
+
+func (c *retainingSpanBatchClient) SendSpan(context.Context) (pb.Span_SendSpanClient, error) {
+	panic("not used")
+}
+
+func (c *retainingSpanBatchClient) SendSpanBatch(_ context.Context, in *pb.PSpanMessageBatch) (*pb.PSpanResultBatch, error) {
+	c.request = in
+	return &pb.PSpanResultBatch{}, nil
+}
+
+// grpc-go tracing retains request pointers after Send returns. Those requests
+// must be detached from the slabs before their builders are recycled.
+func Test_spanGrpc_tracingRetainsStableMessages(t *testing.T) {
+	previous := grpc.EnableTracing
+	grpc.EnableTracing = true
+	defer func() { grpc.EnableTracing = previous }()
+
+	agent := newTestAgent(defaultConfig())
+	streamClient := &retainingSpanSendClient{}
+	stream := &spanStream{stream: streamClient, cancel: func() {}}
+	assert.NoError(t, stream.sendSpan(slabTestChunk(agent, 7, 3)))
+	assert.NoError(t, verifySeedMessage(streamClient.request, 7, 3))
+
+	batchClient := &retainingSpanBatchClient{}
+	spanGrpc := &spanGrpc{
+		spanClient:              batchClient,
+		agent:                   agent,
+		batchFlushTimeout:       time.Second,
+		maxConcurrentRequests:   1,
+		concurrentRequestPermit: make(chan struct{}, 1),
+	}
+	spanGrpc.sendSpanBatchAsync([]*spanChunk{slabTestChunk(agent, 8, 3)})
+	spanGrpc.inFlight.Wait()
+	if assert.Len(t, batchClient.request.GetSpan(), 1) {
+		assert.NoError(t, verifySeedMessage(batchClient.request.GetSpan()[0], 8, 3))
 	}
 }
 


### PR DESCRIPTION
Closes #165

## What

Builds the span transport's protobuf message graphs on a `sync.Pool`-backed builder of value-typed slabs (`span_slab.go`) and recycles the whole graph once the send completes — the Go stand-in for the C++ agent's per-call `google::protobuf::Arena` + `arena_.Reset()`.

- `makePSpan` / `makePSpanChunk` / `makePSpanEvent` / `makePSpanMessageBatch` become builder methods; the duplicated final/async dispatch in `sendSpan` and the batch path is unified in `makePSpanMessage`.
- `annotationValue.toProto` -> `toProtoInto(builder)`; non-transport callers (`JsonString`) keep `getList()` via a throwaway builder.
- Ownership boundaries are explicit and commented: the stream path releases the builder after `stream.Send` returns (grpc-go marshals synchronously inside `SendMsg`, including on error or timeout-cancel), the batch path releases in the async goroutine after the unary call returns, and the skipped-batch path releases immediately.
- The test mock now clones recorded batch requests (`proto.Clone`) the way the real transport marshals them during the call, instead of retaining live pointers into recycled memory.

No change to the wire protocol or the default transport (`Span.Batch.Enable` stays `false`).

## Numbers

`go test -bench=Benchmark_spanTransport -benchmem` (Apple M1 Pro, 10-event span with one SQL annotation per event):

| benchmark | before | after |
|---|---|---|
| makePSpan (conversion) | 2,071 ns / 5,572 B / 91 allocs | 551 ns / 0 B / 0 allocs |
| makePSpan + proto.Marshal | 5,882 ns / 6,468 B / 92 | 4,203 ns / 896 B / 1 |
| makePSpanMessageBatch (50 spans) | 121,317 ns / 279 KB / 4,552 | 25,030 ns / 64 B / 1 |
| makePSpan (50 events) | 10,455 ns / 25 KB / 411 | 2,288 ns / 0 B / 0 |

Steady-state conversion is allocation-free; what remains is the batch wrapper message and the marshal output buffer.

## Verification

- `span_slab_test.go`: reused-builder output equals fresh-builder output (`proto.Equal`); error info / next event / async-chunk slab paths verified by content; the stream contract reproduced (bytes marshaled at Send time stay intact after the builder is recycled); a concurrent-batch no-mixing test (4 senders x 25 batches x 5 spans, 8 in-flight requests, every seed-derived field cross-checked at receive time while the sender still owns the builder).
- `go test -race -count=1 ./...` passes; `go vet` / `gofmt` clean.
- New `grpc_bench_test.go` also carries stream-vs-batch agent-side comparison benchmarks over a marshal-performing stub (no transport default changed; numbers in #165).
