### PR TITLE
[#160] Size the url stat queue on its own key and count dropped records

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -41,6 +41,13 @@ type agent struct {
 	urlStatChan chan *urlStat
 	statChan    chan *pb.PStatMessage
 
+	// urlStatDrops is the cumulative count of url stat records lost to a full
+	// queue, updated from the request path. urlStatDropReportAt is the unix
+	// nano before which the overflow warning stays silent; it starts at zero
+	// so the first drop always reports.
+	urlStatDrops        atomic.Int64
+	urlStatDropReportAt atomic.Int64
+
 	errorCache  *metaCache[string, int32]
 	errorIdGen  int32
 	sqlCache    *metaCache[string, int32]
@@ -112,6 +119,9 @@ type exception struct {
 const (
 	cacheSize        = 1024
 	defaultQueueSize = 1024
+	// urlStatDropReportInterval bounds how often a saturated url stat queue
+	// may warn, matching the C++ QueueDropReporter::kDefaultReportInterval.
+	urlStatDropReportInterval = 60 * time.Second
 
 	defaultSpanBatchSize                  = 50
 	defaultSpanBatchFlushInterval         = 1000
@@ -176,7 +186,7 @@ func NewAgent(config *Config) (Agent, error) {
 		startTime:   time.Now().UnixNano() / int64(time.Millisecond),
 		spanQueue:   newSpanQueue(config.Int(CfgSpanQueueSize)),
 		metaChan:    make(chan interface{}, config.Int(CfgSpanQueueSize)),
-		urlStatChan: make(chan *urlStat, config.Int(CfgSpanQueueSize)),
+		urlStatChan: make(chan *urlStat, config.Int(CfgHttpUrlStatQueueSize)),
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),
 		config:      config,
 	}
@@ -709,14 +719,35 @@ func (agent *agent) enqueueUrlStat(stat *urlStat) bool {
 		break
 	}
 
+	// The queue is full: stat is rejected, and the oldest queued record is
+	// evicted on top of it to leave room for the next enqueue (unless the
+	// consumer already drained one meanwhile). Both are records the snapshot
+	// will never see, so both are counted.
+	dropped := int64(1)
 	select {
 	case <-agent.urlStatChan:
+		dropped++
 	default:
 	}
-	if IsTraceLogLevelEnabled() {
-		Log("agent").Tracef("url stat channel - max capacity reached or closed")
-	}
+	agent.reportUrlStatDrops(dropped)
 	return false
+}
+
+// reportUrlStatDrops adds n to the cumulative drop count and logs the running
+// total at most once per urlStatDropReportInterval. WARN so the data loss is
+// visible at the default log level, rate-limited so a saturated queue cannot
+// log once per dropped request from the request path. Mirrors the C++ agent's
+// QueueDropReporter::record().
+func (agent *agent) reportUrlStatDrops(n int64) {
+	total := agent.urlStatDrops.Add(n)
+
+	now := time.Now().UnixNano()
+	next := agent.urlStatDropReportAt.Load()
+	if now < next || !agent.urlStatDropReportAt.CompareAndSwap(next, now+int64(urlStatDropReportInterval)) {
+		return
+	}
+	Log("agent").Warnf("url stat queue overflow: %d dropped in total (max queue size %d)",
+		total, cap(agent.urlStatChan))
 }
 
 func (agent *agent) collectUrlStatWorker() {
@@ -824,7 +855,7 @@ func NewTestAgent(config *Config, t *testing.T) (Agent, error) {
 		startTime:   time.Now().UnixNano() / int64(time.Millisecond),
 		spanQueue:   newSpanQueue(config.Int(CfgSpanQueueSize)),
 		metaChan:    make(chan interface{}, config.Int(CfgSpanQueueSize)),
-		urlStatChan: make(chan *urlStat, config.Int(CfgSpanQueueSize)),
+		urlStatChan: make(chan *urlStat, config.Int(CfgHttpUrlStatQueueSize)),
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),
 		config:      config,
 	}

--- a/agent_test.go
+++ b/agent_test.go
@@ -1,11 +1,15 @@
 package pinpoint
 
 import (
+	"bytes"
+	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -319,4 +323,94 @@ func Test_agent_ShutdownNoStartupDelay(t *testing.T) {
 	a.Shutdown()
 
 	assert.Less(t, time.Since(start), connectGraceTimeout, "no unconditional sleep")
+}
+
+// captureWarnLog redirects the agent log to buf until the returned func is called.
+func captureWarnLog(buf *bytes.Buffer) func() {
+	prevOut, prevLevel := logger.defaultLogger.Out, logger.defaultLogger.GetLevel()
+	logger.defaultLogger.SetOutput(buf)
+	logger.defaultLogger.SetLevel(logrus.WarnLevel)
+	return func() {
+		logger.defaultLogger.SetOutput(prevOut)
+		logger.defaultLogger.SetLevel(prevLevel)
+	}
+}
+
+func Test_agent_enqueueUrlStatCountsEveryDroppedRecord(t *testing.T) {
+	const queueSize, enqueued = 4, 100
+
+	agent := newTestAgent(defaultConfig())
+	agent.urlStatChan = make(chan *urlStat, queueSize)
+	defer captureWarnLog(&bytes.Buffer{})()
+
+	for i := 0; i < enqueued; i++ {
+		agent.enqueueUrlStat(&urlStat{})
+	}
+
+	close(agent.urlStatChan)
+	queued := 0
+	for range agent.urlStatChan {
+		queued++
+	}
+
+	// Nothing drained the queue while it filled, so every record that is not
+	// still sitting in it was dropped - both the rejected enqueues and the
+	// oldest entries evicted to make room for them.
+	assert.Equal(t, int64(enqueued-queued), agent.urlStatDrops.Load(),
+		"drop counter must account for every record that never reached the consumer")
+}
+
+func Test_agent_enqueueUrlStatCountsDropsFromConcurrentProducers(t *testing.T) {
+	const producers, perProducer = 8, 250
+
+	agent := newTestAgent(defaultConfig())
+	agent.urlStatChan = make(chan *urlStat, 4)
+	defer captureWarnLog(&bytes.Buffer{})()
+
+	var wg sync.WaitGroup
+	for i := 0; i < producers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perProducer; j++ {
+				agent.enqueueUrlStat(&urlStat{})
+			}
+		}()
+	}
+	wg.Wait()
+
+	close(agent.urlStatChan)
+	queued := 0
+	for range agent.urlStatChan {
+		queued++
+	}
+
+	assert.Equal(t, int64(producers*perProducer-queued), agent.urlStatDrops.Load())
+}
+
+func Test_agent_enqueueUrlStatRateLimitsOverflowWarning(t *testing.T) {
+	const queueSize, enqueued = 4, 100
+
+	agent := newTestAgent(defaultConfig())
+	agent.urlStatChan = make(chan *urlStat, queueSize)
+
+	var buf bytes.Buffer
+	defer captureWarnLog(&buf)()
+
+	for i := 0; i < enqueued; i++ {
+		agent.enqueueUrlStat(&urlStat{})
+	}
+
+	assert.Greater(t, agent.urlStatDrops.Load(), int64(1), "test did not saturate the queue")
+	assert.Equal(t, 1, strings.Count(buf.String(), "url stat queue overflow"),
+		"a saturated queue must warn once per report interval, not once per dropped record")
+
+	// The next drop after the report interval elapses warns again, carrying the
+	// running total rather than restarting the count.
+	agent.urlStatDropReportAt.Store(0)
+	agent.enqueueUrlStat(&urlStat{})
+
+	assert.Equal(t, 2, strings.Count(buf.String(), "url stat queue overflow"))
+	assert.Contains(t, buf.String(), fmt.Sprintf("%d dropped in total (max queue size %d)",
+		agent.urlStatDrops.Load(), queueSize))
 }

--- a/config.go
+++ b/config.go
@@ -56,6 +56,7 @@ const (
 	CfgEnable                         = "Enable"
 	CfgHttpUrlStatEnable              = "Http.UrlStat.Enable"
 	CfgHttpUrlStatLimitSize           = "Http.UrlStat.LimitSize"
+	CfgHttpUrlStatQueueSize           = "Http.UrlStat.QueueSize"
 	CfgHttpUrlStatWithMethod          = "Http.UrlStat.WithMethod"
 	CfgErrorTraceCallStack            = "Error.TraceCallStack"
 	CfgErrorCallStackDepth            = "Error.CallStackDepth"
@@ -134,6 +135,7 @@ func initConfig() {
 	AddConfig(CfgEnable, CfgBool, true, false)
 	AddConfig(CfgHttpUrlStatEnable, CfgBool, false, true)
 	AddConfig(CfgHttpUrlStatLimitSize, CfgInt, 1024, true)
+	AddConfig(CfgHttpUrlStatQueueSize, CfgInt, defaultQueueSize, false)
 	AddConfig(CfgHttpUrlStatWithMethod, CfgBool, false, true)
 	AddConfig(CfgErrorTraceCallStack, CfgBool, false, true)
 	AddConfig(CfgErrorCallStackDepth, CfgInt, 32, true)
@@ -333,6 +335,9 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 	}
 	if config.stagedInt(CfgSpanQueueSize) < 1 {
 		config.cfgMap[CfgSpanQueueSize].value = defaultQueueSize
+	}
+	if config.stagedInt(CfgHttpUrlStatQueueSize) < 1 {
+		config.cfgMap[CfgHttpUrlStatQueueSize].value = defaultQueueSize
 	}
 	if config.stagedInt(CfgSpanBatchSize) < 1 {
 		config.cfgMap[CfgSpanBatchSize].value = defaultSpanBatchSize
@@ -1012,6 +1017,14 @@ func WithHttpUrlStatEnable(enable bool) ConfigOption {
 func WithHttpUrlStatLimitSize(size int) ConfigOption {
 	return func(c *Config) {
 		c.cfgMap[CfgHttpUrlStatLimitSize].value = size
+	}
+}
+
+// WithHttpUrlStatQueueSize sets the size of the queue buffering per-request URL
+// statistics records until they are aggregated into a snapshot.
+func WithHttpUrlStatQueueSize(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgHttpUrlStatQueueSize].value = size
 	}
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -66,6 +66,7 @@ func TestNewConfig_DefaultValue(t *testing.T) {
 			assert.Equal(t, true, c.Bool(CfgEnable), CfgEnable)
 			assert.Equal(t, false, c.Bool(CfgHttpUrlStatEnable), CfgHttpUrlStatEnable)
 			assert.Equal(t, 1024, c.Int(CfgHttpUrlStatLimitSize), CfgHttpUrlStatLimitSize)
+			assert.Equal(t, 1024, c.Int(CfgHttpUrlStatQueueSize), CfgHttpUrlStatQueueSize)
 			assert.Equal(t, false, c.Bool(CfgErrorTraceCallStack), CfgErrorTraceCallStack)
 			assert.Equal(t, 32, c.Int(CfgErrorCallStackDepth), CfgErrorCallStackDepth)
 		})
@@ -711,4 +712,21 @@ func Test_reloadConfig_keepsSamplerWhenSamplingUnchanged(t *testing.T) {
 	assert.NoError(t, os.WriteFile(cfgFile, []byte("Sampling:\n  NewThroughput: 20\n"), 0o600))
 	config.reloadConfig(cfgFileViper)
 	assert.NotSame(t, sampler, config.load().sampler, "sampling change did not rebuild the sampler")
+}
+
+func TestNewConfig_HttpUrlStatQueueSizeIsIndependentOfSpanQueueSize(t *testing.T) {
+	c, err := NewConfig(WithAppName("TestApp"), WithSpanQueueSize(8192))
+	assert.NoError(t, err)
+	assert.Equal(t, 8192, c.Int(CfgSpanQueueSize), CfgSpanQueueSize)
+	assert.Equal(t, defaultQueueSize, c.Int(CfgHttpUrlStatQueueSize), CfgHttpUrlStatQueueSize)
+
+	c, err = NewConfig(WithAppName("TestApp"), WithHttpUrlStatQueueSize(64))
+	assert.NoError(t, err)
+	assert.Equal(t, 64, c.Int(CfgHttpUrlStatQueueSize), CfgHttpUrlStatQueueSize)
+	assert.Equal(t, defaultQueueSize, c.Int(CfgSpanQueueSize), CfgSpanQueueSize)
+
+	// Same lower-bound guard the span queue gets.
+	c, err = NewConfig(WithAppName("TestApp"), WithHttpUrlStatQueueSize(0))
+	assert.NoError(t, err)
+	assert.Equal(t, defaultQueueSize, c.Int(CfgHttpUrlStatQueueSize), CfgHttpUrlStatQueueSize)
 }

--- a/doc/config.md
+++ b/doc/config.md
@@ -691,6 +691,19 @@ Http.UrlStat.LimitSize option sets the limit size of the URLs to be collected.
 * default: 1024
 * dynamic
 
+### Http.UrlStat.QueueSize
+Http.UrlStat.QueueSize option sets the size of the agent's URL statistics queue.
+This queue buffers the per-request URL records waiting to be aggregated into a snapshot,
+unlike Http.UrlStat.LimitSize which caps the number of distinct URLs kept in one snapshot.
+When the queue is full the records are dropped, and the agent logs a rate-limited warning
+carrying the cumulative number of dropped records.
+
+* --pinpoint-http-urlstat-queuesize
+* PINPOINT_GO_HTTP_URLSTAT_QUEUESIZE
+* WithHttpUrlStatQueueSize()
+* type: int
+* default: 1024
+
 ### Http.UrlStat.WithMethod
 Http.UrlStat.WithMethod option adds http method as prefix to url string key.
 


### PR DESCRIPTION
Closes #160

## What

`urlStatChan` took its capacity from `Span.QueueSize`, so growing the URL statistics buffer meant growing the span queue with it, and an overflow left nothing behind but a trace-level line — invisible at the default log level and carrying no cumulative figure.

1. **`Http.UrlStat.QueueSize`** — a config key of its own, following the existing `Http.UrlStat.*` naming, with `WithHttpUrlStatQueueSize()`, the `--pinpoint-http-urlstat-queuesize` flag and `PINPOINT_GO_HTTP_URLSTAT_QUEUESIZE`. Non-dynamic and lower-bound guarded, exactly like `Span.QueueSize`, since the channel is sized once when the agent is built.

2. **Drop accounting** — an atomic cumulative counter (the enqueue path is the request path) reported as a rate-limited `WARN`, mirroring the C++ `QueueDropReporter::record()`: 60s interval, the first drop always reports, one caller claims each window by CAS, same message:

   ```
   url stat queue overflow: 96 dropped in total (max queue size 4)
   ```

   This replaces the `Tracef` line, which could not be seen at the default log level and had no total.

## Default is 1024

`Span.QueueSize` already defaults to `1024`, so the URL stat queue keeps exactly the capacity it has today under the default configuration, and the value matches the C++ agent's `HTTP_URL_STAT_QUEUE_SIZE`.

⚠️ One behavior change worth a release note: anyone who tuned `Span.QueueSize` away from its default and relied on the URL stat queue following it now has to set `Http.UrlStat.QueueSize` as well.

## Why the counter adds 2 per overflow

On a full queue `enqueueUrlStat` rejects the incoming record **and** evicts the oldest queued one to leave room for the next enqueue. Both are records the snapshot will never see, so both are counted. That gives an exact invariant the tests assert:

```
total enqueues == records left in the queue + drop counter
```

The drop *policy* itself is untouched here — note that the span queue's `enqueueOrOverwrite` evicts and then stores the new chunk, losing one record per overflow rather than two. Worth a separate look; out of scope for this change.

## Tests

- `Test_agent_enqueueUrlStatCountsEveryDroppedRecord` — queue of 4, 100 records in, counter == 96 == `100 - 4` left in the queue.
- `Test_agent_enqueueUrlStatCountsDropsFromConcurrentProducers` — 8 goroutines × 250 records, same invariant under `-race`.
- `Test_agent_enqueueUrlStatRateLimitsOverflowWarning` — 96 drops produce exactly one warning; once the window is expired the next drop warns again with the running total, not a fresh count.
- `TestNewConfig_HttpUrlStatQueueSizeIsIndependentOfSpanQueueSize` — either key moves without dragging the other; `0` falls back to the default.

Mutation-checked: counting only the rejected record fails the first test (`expected 96, actual 48`), and removing the rate limit fails the third (`expected 1, actual 48`).

`go test -race ./...` passes on the root module. `test/it` passes without `-race`; under `-race` it fails identically on `main` at 2b27dfd (pre-existing mixed atomic/plain access to `gAtcStreamCount` in `command.go:26,102,106`), unrelated to this change.
