### PR TITLE
[#161] Expose AgentInfo refresh interval and retry policy as configuration

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -128,6 +128,12 @@ const (
 	defaultSpanBatchCollectDeadline       = 500
 	defaultSpanBatchMaxConcurrentRequests = 10
 
+	// AgentInfo refresh, matching the C++ agent's Collector.AgentInfo defaults
+	// except the interval: 0 keeps the refresh off, preserving the historical
+	// Go behavior of sending AgentInfo only once at startup.
+	defaultAgentInfoSendRetryInterval = 3000
+	defaultAgentInfoMaxTryPerAttempt  = 3
+
 	// shutdownTimeout bounds how long Shutdown waits for the worker goroutines
 	// to drain their queues before abandoning them.
 	shutdownTimeout = 3 * time.Second
@@ -242,6 +248,37 @@ func (agent *agent) connectGrpcServer() {
 	go agent.collectUrlStatWorker()
 	go agent.sendUrlStatWorker()
 	go agent.sendStatsWorker()
+
+	if interval := time.Duration(agent.config.Int(CfgCollectorAgentInfoRefreshInterval)) * time.Millisecond; interval > 0 {
+		agent.workerWg.Add(1)
+		go agent.refreshAgentInfoWorker(interval)
+	}
+}
+
+// refreshAgentInfoWorker re-sends AgentInfo every refresh interval, mirroring
+// the C++ agent's AgentInfo scheduler. Best-effort: a failed cycle waits for
+// the next interval and never affects the agent's enabled state.
+func (agent *agent) refreshAgentInfoWorker(interval time.Duration) {
+	Log("agent").Infof("start agent info refresh goroutine")
+	defer agent.workerWg.Done()
+
+	retryInterval := time.Duration(agent.config.Int(CfgCollectorAgentInfoSendRetryInterval)) * time.Millisecond
+	maxTry := agent.config.Int(CfgCollectorAgentInfoMaxTryPerAttempt)
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	stop := agent.stopSignal().Done()
+
+	for {
+		select {
+		case <-stop:
+			Log("agent").Infof("end agent info refresh goroutine")
+			return
+		case <-timer.C:
+		}
+		agent.agentGrpc.refreshAgentInfo(maxTry, retryInterval)
+		timer.Reset(interval)
+	}
 }
 
 // stopSignal returns a context cancelled when shutdown begins. Reconnect waits

--- a/config.go
+++ b/config.go
@@ -17,14 +17,18 @@ import (
 
 // Config option keys
 const (
-	CfgAppName                        = "ApplicationName"
-	CfgAppType                        = "ApplicationType"
-	CfgAgentID                        = "AgentID"
-	CfgAgentName                      = "AgentName"
-	CfgCollectorHost                  = "Collector.Host"
-	CfgCollectorAgentPort             = "Collector.AgentPort"
-	CfgCollectorSpanPort              = "Collector.SpanPort"
-	CfgCollectorStatPort              = "Collector.StatPort"
+	CfgAppName                             = "ApplicationName"
+	CfgAppType                             = "ApplicationType"
+	CfgAgentID                             = "AgentID"
+	CfgAgentName                           = "AgentName"
+	CfgCollectorHost                       = "Collector.Host"
+	CfgCollectorAgentPort                  = "Collector.AgentPort"
+	CfgCollectorSpanPort                   = "Collector.SpanPort"
+	CfgCollectorStatPort                   = "Collector.StatPort"
+	CfgCollectorAgentInfoRefreshInterval   = "Collector.AgentInfo.RefreshInterval"
+	CfgCollectorAgentInfoSendRetryInterval = "Collector.AgentInfo.SendRetryInterval"
+	CfgCollectorAgentInfoMaxTryPerAttempt  = "Collector.AgentInfo.MaxTryPerAttempt"
+
 	CfgLogLevelOld                    = "LogLevel"
 	CfgLogLevel                       = "Log.Level"
 	CfgLogOutput                      = "Log.Output"
@@ -104,6 +108,9 @@ func initConfig() {
 	AddConfig(CfgCollectorAgentPort, CfgInt, 9991, false)
 	AddConfig(CfgCollectorSpanPort, CfgInt, 9993, false)
 	AddConfig(CfgCollectorStatPort, CfgInt, 9992, false)
+	AddConfig(CfgCollectorAgentInfoRefreshInterval, CfgInt, 0, false)
+	AddConfig(CfgCollectorAgentInfoSendRetryInterval, CfgInt, defaultAgentInfoSendRetryInterval, false)
+	AddConfig(CfgCollectorAgentInfoMaxTryPerAttempt, CfgInt, defaultAgentInfoMaxTryPerAttempt, false)
 	AddConfig(CfgLogLevelOld, CfgString, "info", true)
 	AddConfig(CfgLogLevel, CfgString, "info", true)
 	AddConfig(CfgLogOutput, CfgString, "stderr", true)
@@ -350,6 +357,12 @@ func NewConfig(opts ...ConfigOption) (*Config, error) {
 	}
 	if config.stagedInt(CfgSpanBatchMaxConcurrentRequests) < 1 {
 		config.cfgMap[CfgSpanBatchMaxConcurrentRequests].value = defaultSpanBatchMaxConcurrentRequests
+	}
+	if config.stagedInt(CfgCollectorAgentInfoSendRetryInterval) < 1 {
+		config.cfgMap[CfgCollectorAgentInfoSendRetryInterval].value = defaultAgentInfoSendRetryInterval
+	}
+	if config.stagedInt(CfgCollectorAgentInfoMaxTryPerAttempt) < 1 {
+		config.cfgMap[CfgCollectorAgentInfoMaxTryPerAttempt].value = defaultAgentInfoMaxTryPerAttempt
 	}
 	config.publish()
 
@@ -804,6 +817,30 @@ func WithCollectorSpanPort(port int) ConfigOption {
 func WithCollectorStatPort(port int) ConfigOption {
 	return func(c *Config) {
 		c.cfgMap[CfgCollectorStatPort].value = port
+	}
+}
+
+// WithCollectorAgentInfoRefreshInterval sets the cycle for re-sending the agent information
+// to the collector, in milliseconds. If 0 or less, it is sent only once at startup.
+func WithCollectorAgentInfoRefreshInterval(interval int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorAgentInfoRefreshInterval].value = interval
+	}
+}
+
+// WithCollectorAgentInfoSendRetryInterval sets the wait between agent information send retries
+// within one refresh cycle, in milliseconds.
+func WithCollectorAgentInfoSendRetryInterval(interval int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorAgentInfoSendRetryInterval].value = interval
+	}
+}
+
+// WithCollectorAgentInfoMaxTryPerAttempt sets the max number of agent information sends
+// per refresh cycle.
+func WithCollectorAgentInfoMaxTryPerAttempt(count int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorAgentInfoMaxTryPerAttempt].value = count
 	}
 }
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -252,6 +252,38 @@ Collector.StatPort option sets the stat port of Pinpoint collector.
 * int
 * default: 9992
 
+### Collector.AgentInfo.RefreshInterval
+Collector.AgentInfo.RefreshInterval option sets the cycle for re-sending the agent information to the collector.
+If it is 0 or less, the agent information is sent only once at agent startup.
+
+* --pinpoint-collector-agentinfo-refreshinterval
+* PINPOINT_GO_COLLECTOR_AGENTINFO_REFRESHINTERVAL
+* WithCollectorAgentInfoRefreshInterval()
+* type: int
+* default: 0 (disabled)
+* unit: milliseconds
+
+### Collector.AgentInfo.SendRetryInterval
+Collector.AgentInfo.SendRetryInterval option sets the wait between agent information send retries within one refresh cycle.
+It has no effect unless Collector.AgentInfo.RefreshInterval is set.
+
+* --pinpoint-collector-agentinfo-sendretryinterval
+* PINPOINT_GO_COLLECTOR_AGENTINFO_SENDRETRYINTERVAL
+* WithCollectorAgentInfoSendRetryInterval()
+* type: int
+* default: 3000
+* unit: milliseconds
+
+### Collector.AgentInfo.MaxTryPerAttempt
+Collector.AgentInfo.MaxTryPerAttempt option sets the max number of agent information sends per refresh cycle.
+It has no effect unless Collector.AgentInfo.RefreshInterval is set.
+
+* --pinpoint-collector-agentinfo-maxtryperattempt
+* PINPOINT_GO_COLLECTOR_AGENTINFO_MAXTRYPERATTEMPT
+* WithCollectorAgentInfoMaxTryPerAttempt()
+* type: int
+* default: 3
+
 ### Sampling.Type
 Sampling.Type option sets the type of agent sampler.
 Either "COUNTER" or "PERCENT" must be specified.

--- a/grpc.go
+++ b/grpc.go
@@ -323,6 +323,31 @@ func (agentGrpc *agentGrpc) registerAgentWithRetry() bool {
 	return false
 }
 
+// refreshAgentInfo re-sends AgentInfo once, trying up to maxTry sends spaced
+// retryInterval apart. Unlike boot-time registration it never loops forever:
+// a failed refresh is simply left for the next refresh cycle, mirroring the
+// C++ agent's send_agent_info_with_retries.
+func (agentGrpc *agentGrpc) refreshAgentInfo(maxTry int, retryInterval time.Duration) bool {
+	ctx, agentInfo := agentGrpc.makeAgentInfo()
+
+	for try := 0; try < maxTry && !agentGrpc.agent.shutdown.Load(); try++ {
+		if res, err := agentGrpc.sendAgentInfo(ctx, agentInfo); err == nil && res.Success {
+			Log("agent").Infof("success to refresh agent info")
+			return true
+		}
+		if try+1 < maxTry {
+			select {
+			case <-agentGrpc.agent.stopSignal().Done():
+				return false
+			case <-time.After(retryInterval):
+			}
+		}
+	}
+
+	Log("agent").Warnf("failed to refresh agent info")
+	return false
+}
+
 func isRetryableError(e error) bool {
 	// retry only for network error
 	code := status.Code(e)

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -626,3 +626,76 @@ func Test_sendStreamWithTimeout_unresponsiveStreamLeaksNothing(t *testing.T) {
 	}
 	assert.LessOrEqual(t, runtime.NumGoroutine(), before+2)
 }
+
+// countingAgentClient counts RequestAgentInfo calls and fails them on demand.
+type countingAgentClient struct {
+	calls atomic.Int32
+	fail  atomic.Bool
+}
+
+func (c *countingAgentClient) RequestAgentInfo(ctx context.Context, agentInfo *pb.PAgentInfo) (*pb.PResult, error) {
+	c.calls.Add(1)
+	if c.fail.Load() {
+		return nil, status.Errorf(codes.Unavailable, "collector down")
+	}
+	return &pb.PResult{Success: true}, nil
+}
+
+func (c *countingAgentClient) PingSession(ctx context.Context) (pb.Agent_PingSessionClient, error) {
+	return nil, status.Errorf(codes.Unimplemented, "not used")
+}
+
+func Test_config_agentInfoRefreshDisabledByDefault(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	assert.Equal(t, 0, cfg.Int(CfgCollectorAgentInfoRefreshInterval))
+	assert.Equal(t, defaultAgentInfoSendRetryInterval, cfg.Int(CfgCollectorAgentInfoSendRetryInterval))
+	assert.Equal(t, defaultAgentInfoMaxTryPerAttempt, cfg.Int(CfgCollectorAgentInfoMaxTryPerAttempt))
+}
+
+func Test_agentGrpc_refreshAgentInfo_stopsAtMaxTry(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	client := &countingAgentClient{}
+	client.fail.Store(true)
+	agentGrpc := &agentGrpc{agentClient: client, agent: agent}
+
+	ok := agentGrpc.refreshAgentInfo(3, time.Millisecond)
+
+	assert.False(t, ok, "refresh must give up after maxTry sends")
+	assert.EqualValues(t, 3, client.calls.Load())
+}
+
+func Test_agentGrpc_refreshAgentInfo_stopsOnSuccess(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	client := &countingAgentClient{}
+	agentGrpc := &agentGrpc{agentClient: client, agent: agent}
+
+	ok := agentGrpc.refreshAgentInfo(3, time.Millisecond)
+
+	assert.True(t, ok)
+	assert.EqualValues(t, 1, client.calls.Load())
+}
+
+func Test_agent_refreshAgentInfoWorker_honorsInterval(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"),
+		WithCollectorAgentInfoRefreshInterval(20),
+		WithCollectorAgentInfoSendRetryInterval(10),
+		WithCollectorAgentInfoMaxTryPerAttempt(1),
+	)
+	agent := newTestAgent(cfg)
+	client := &countingAgentClient{}
+	agent.agentGrpc = &agentGrpc{agentClient: client, agent: agent}
+
+	agent.workerWg.Add(1)
+	go agent.refreshAgentInfoWorker(20 * time.Millisecond)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for client.calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	agent.signalShutdown()
+	agent.workerWg.Wait()
+
+	assert.GreaterOrEqual(t, client.calls.Load(), int32(2), "worker must re-send agent info every interval")
+}


### PR DESCRIPTION
Resolves #161

## Summary

Adds three configuration keys so the AgentInfo registration refresh cycle and its retry policy are tunable, matching the C++ agent's `Collector.AgentInfo.*` options while following the Go agent's naming conventions (no `Ms` suffix; unit documented as milliseconds, like `Stat.CollectInterval`):

| Key | Type | Default | Meaning |
|---|---|---|---|
| `Collector.AgentInfo.RefreshInterval` | int (ms) | `0` (disabled) | Cycle for re-sending AgentInfo; ≤0 keeps the current send-once-at-startup behavior |
| `Collector.AgentInfo.SendRetryInterval` | int (ms) | `3000` | Wait between sends within one refresh cycle |
| `Collector.AgentInfo.MaxTryPerAttempt` | int | `3` | Max sends per refresh cycle |

## Changes

- `config.go`: new keys, defaults, `<1` clamps, and `WithCollectorAgentInfo*()` options; env vars and command-line flags are derived automatically.
- `grpc.go`: `refreshAgentInfo()` — one refresh cycle, up to `MaxTryPerAttempt` sends spaced `SendRetryInterval` apart, aborting on shutdown. Mirrors the C++ agent's `send_agent_info_with_retries`; never loops forever.
- `agent.go`: `refreshAgentInfoWorker()` started from `connectGrpcServer` only when `RefreshInterval > 0`, stopped via the agent's stop signal. Boot-time registration is unchanged.
- `doc/config.md`: documented the three options.

Defaults preserve today's behavior exactly: with `RefreshInterval=0` no worker is started, so existing deployments are unaffected.

## Testing

- New tests: default is disabled; a refresh cycle stops at the configured max tries; a successful send stops after one try; the worker re-sends every interval and exits on shutdown.
- `go build ./...`, `go vet`, and `go test -race ./...` pass.
