### PR TITLE
[#162] Make the gRPC channel options configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -29,6 +29,18 @@ const (
 	CfgCollectorAgentInfoSendRetryInterval = "Collector.AgentInfo.SendRetryInterval"
 	CfgCollectorAgentInfoMaxTryPerAttempt  = "Collector.AgentInfo.MaxTryPerAttempt"
 
+	// Collector.Grpc.* mirrors the C++ agent's channel option keys; time values
+	// are in milliseconds without a "Ms" suffix, following the convention of
+	// the other millisecond keys (Stat.CollectInterval, Span.BatchFlushInterval).
+	CfgCollectorGrpcKeepAliveTime               = "Collector.Grpc.KeepAliveTime"
+	CfgCollectorGrpcKeepAliveTimeout            = "Collector.Grpc.KeepAliveTimeout"
+	CfgCollectorGrpcKeepAlivePermitWithoutCalls = "Collector.Grpc.KeepAlivePermitWithoutCalls"
+	CfgCollectorGrpcMaxSendMessageSize          = "Collector.Grpc.MaxSendMessageSize"
+	CfgCollectorGrpcMaxReceiveMessageSize       = "Collector.Grpc.MaxReceiveMessageSize"
+	CfgCollectorGrpcFlowControlWindow           = "Collector.Grpc.FlowControlWindow"
+	CfgCollectorGrpcWriteBufferSize             = "Collector.Grpc.WriteBufferSize"
+	CfgCollectorGrpcMaxHeaderListSize           = "Collector.Grpc.MaxHeaderListSize"
+
 	CfgLogLevelOld                    = "LogLevel"
 	CfgLogLevel                       = "Log.Level"
 	CfgLogOutput                      = "Log.Output"
@@ -111,6 +123,14 @@ func initConfig() {
 	AddConfig(CfgCollectorAgentInfoRefreshInterval, CfgInt, 0, false)
 	AddConfig(CfgCollectorAgentInfoSendRetryInterval, CfgInt, defaultAgentInfoSendRetryInterval, false)
 	AddConfig(CfgCollectorAgentInfoMaxTryPerAttempt, CfgInt, defaultAgentInfoMaxTryPerAttempt, false)
+	AddConfig(CfgCollectorGrpcKeepAliveTime, CfgInt, grpcKeepAliveTime, false)
+	AddConfig(CfgCollectorGrpcKeepAliveTimeout, CfgInt, grpcKeepAliveTimeout, false)
+	AddConfig(CfgCollectorGrpcKeepAlivePermitWithoutCalls, CfgBool, grpcKeepAlivePermitWithoutCalls, false)
+	AddConfig(CfgCollectorGrpcMaxSendMessageSize, CfgInt, grpcMaxMessageSize, false)
+	AddConfig(CfgCollectorGrpcMaxReceiveMessageSize, CfgInt, grpcMaxMessageSize, false)
+	AddConfig(CfgCollectorGrpcFlowControlWindow, CfgInt, grpcFlowControlWindow, false)
+	AddConfig(CfgCollectorGrpcWriteBufferSize, CfgInt, grpcWriteBufferSize, false)
+	AddConfig(CfgCollectorGrpcMaxHeaderListSize, CfgInt, grpcMaxHeaderListSize, false)
 	AddConfig(CfgLogLevelOld, CfgString, "info", true)
 	AddConfig(CfgLogLevel, CfgString, "info", true)
 	AddConfig(CfgLogOutput, CfgString, "stderr", true)
@@ -841,6 +861,62 @@ func WithCollectorAgentInfoSendRetryInterval(interval int) ConfigOption {
 func WithCollectorAgentInfoMaxTryPerAttempt(count int) ConfigOption {
 	return func(c *Config) {
 		c.cfgMap[CfgCollectorAgentInfoMaxTryPerAttempt].value = count
+	}
+}
+
+// WithCollectorGrpcKeepAliveTime sets the gRPC keepalive ping interval in milliseconds.
+func WithCollectorGrpcKeepAliveTime(ms int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcKeepAliveTime].value = ms
+	}
+}
+
+// WithCollectorGrpcKeepAliveTimeout sets the gRPC keepalive ping timeout in milliseconds.
+func WithCollectorGrpcKeepAliveTimeout(ms int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcKeepAliveTimeout].value = ms
+	}
+}
+
+// WithCollectorGrpcKeepAlivePermitWithoutCalls sets whether keepalive pings are sent without active streams.
+func WithCollectorGrpcKeepAlivePermitWithoutCalls(permit bool) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcKeepAlivePermitWithoutCalls].value = permit
+	}
+}
+
+// WithCollectorGrpcMaxSendMessageSize sets the max size in bytes of a gRPC message the agent can send.
+func WithCollectorGrpcMaxSendMessageSize(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcMaxSendMessageSize].value = size
+	}
+}
+
+// WithCollectorGrpcMaxReceiveMessageSize sets the max size in bytes of a gRPC message the agent can receive.
+func WithCollectorGrpcMaxReceiveMessageSize(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcMaxReceiveMessageSize].value = size
+	}
+}
+
+// WithCollectorGrpcFlowControlWindow sets the initial HTTP/2 flow-control window size in bytes.
+func WithCollectorGrpcFlowControlWindow(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcFlowControlWindow].value = size
+	}
+}
+
+// WithCollectorGrpcWriteBufferSize sets the gRPC transport write buffer size in bytes.
+func WithCollectorGrpcWriteBufferSize(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcWriteBufferSize].value = size
+	}
+}
+
+// WithCollectorGrpcMaxHeaderListSize sets the max size in bytes of gRPC response headers.
+func WithCollectorGrpcMaxHeaderListSize(size int) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcMaxHeaderListSize].value = size
 	}
 }
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -284,6 +284,83 @@ It has no effect unless Collector.AgentInfo.RefreshInterval is set.
 * type: int
 * default: 3
 
+### Collector.Grpc.KeepAliveTime
+Collector.Grpc.KeepAliveTime option sets the interval in milliseconds after which the agent sends an HTTP/2
+keepalive ping on an idle collector connection.
+The options below apply equally to every collector connection (agent, metadata, span, stat and command channels).
+
+* --pinpoint-collector-grpc-keepalivetime
+* PINPOINT_GO_COLLECTOR_GRPC_KEEPALIVETIME
+* WithCollectorGrpcKeepAliveTime()
+* int
+* default: 30000
+
+### Collector.Grpc.KeepAliveTimeout
+Collector.Grpc.KeepAliveTimeout option sets the time in milliseconds the agent waits for a keepalive ping ack
+before closing the connection.
+
+* --pinpoint-collector-grpc-keepalivetimeout
+* PINPOINT_GO_COLLECTOR_GRPC_KEEPALIVETIMEOUT
+* WithCollectorGrpcKeepAliveTimeout()
+* int
+* default: 60000
+
+### Collector.Grpc.KeepAlivePermitWithoutCalls
+Collector.Grpc.KeepAlivePermitWithoutCalls option sets whether keepalive pings are sent even when there is no
+active stream.
+The default is false, matching the C++ agent. Agents older than this release always behaved as if it were true.
+
+* --pinpoint-collector-grpc-keepalivepermitwithoutcalls
+* PINPOINT_GO_COLLECTOR_GRPC_KEEPALIVEPERMITWITHOUTCALLS
+* WithCollectorGrpcKeepAlivePermitWithoutCalls()
+* type: bool
+* default: false
+
+### Collector.Grpc.MaxSendMessageSize
+Collector.Grpc.MaxSendMessageSize option sets the max size in bytes of a gRPC message the agent can send.
+
+* --pinpoint-collector-grpc-maxsendmessagesize
+* PINPOINT_GO_COLLECTOR_GRPC_MAXSENDMESSAGESIZE
+* WithCollectorGrpcMaxSendMessageSize()
+* int
+* default: 4194304
+
+### Collector.Grpc.MaxReceiveMessageSize
+Collector.Grpc.MaxReceiveMessageSize option sets the max size in bytes of a gRPC message the agent can receive.
+
+* --pinpoint-collector-grpc-maxreceivemessagesize
+* PINPOINT_GO_COLLECTOR_GRPC_MAXRECEIVEMESSAGESIZE
+* WithCollectorGrpcMaxReceiveMessageSize()
+* int
+* default: 4194304
+
+### Collector.Grpc.FlowControlWindow
+Collector.Grpc.FlowControlWindow option sets the initial HTTP/2 flow-control window size in bytes.
+
+* --pinpoint-collector-grpc-flowcontrolwindow
+* PINPOINT_GO_COLLECTOR_GRPC_FLOWCONTROLWINDOW
+* WithCollectorGrpcFlowControlWindow()
+* int
+* default: 1048576
+
+### Collector.Grpc.WriteBufferSize
+Collector.Grpc.WriteBufferSize option sets the gRPC transport write buffer size in bytes.
+
+* --pinpoint-collector-grpc-writebuffersize
+* PINPOINT_GO_COLLECTOR_GRPC_WRITEBUFFERSIZE
+* WithCollectorGrpcWriteBufferSize()
+* int
+* default: 1048576
+
+### Collector.Grpc.MaxHeaderListSize
+Collector.Grpc.MaxHeaderListSize option sets the max size in bytes of gRPC response headers the agent accepts.
+
+* --pinpoint-collector-grpc-maxheaderlistsize
+* PINPOINT_GO_COLLECTOR_GRPC_MAXHEADERLISTSIZE
+* WithCollectorGrpcMaxHeaderListSize()
+* int
+* default: 8192
+
 ### Sampling.Type
 Sampling.Type option sets the type of agent sampler.
 Either "COUNTER" or "PERCENT" must be specified.

--- a/grpc.go
+++ b/grpc.go
@@ -162,33 +162,62 @@ func (metaGrpcClient *metaGrpcClient) RequestExceptionMetaData(ctx context.Conte
 }
 
 const (
-	agentGrpcTimeOut      = 60 * time.Second
-	sendStreamTimeOut     = 5 * time.Second
-	closeStreamTimeOut    = 1 * time.Second
-	commandStreamTimeOut  = 1 * time.Second
-	grpcFlowControlWindow = 1 * 1024 * 1024
-	grpcWriteBufferSize   = 1 * 1024 * 1024
-	grpcMaxMessageSize    = 4 * 1024 * 1024
-	grpcMaxHeaderListSize = 8 * 1024
+	agentGrpcTimeOut     = 60 * time.Second
+	sendStreamTimeOut    = 5 * time.Second
+	closeStreamTimeOut   = 1 * time.Second
+	commandStreamTimeOut = 1 * time.Second
+
+	// Defaults for the Collector.Grpc.* config keys, matching the C++ agent.
+	grpcKeepAliveTime               = 30000 // ms
+	grpcKeepAliveTimeout            = 60000 // ms
+	grpcKeepAlivePermitWithoutCalls = false
+	grpcFlowControlWindow           = 1 * 1024 * 1024
+	grpcWriteBufferSize             = 1 * 1024 * 1024
+	grpcMaxMessageSize              = 4 * 1024 * 1024
+	grpcMaxHeaderListSize           = 8 * 1024
 )
 
-var kacp = keepalive.ClientParameters{
-	Time:                30 * time.Second,
-	Timeout:             60 * time.Second,
-	PermitWithoutStream: true,
+// grpcChannelOptions holds the channel options connectCollector applies to
+// every collector connection, resolved from the Collector.Grpc.* config keys.
+type grpcChannelOptions struct {
+	keepAlive         keepalive.ClientParameters
+	flowControlWindow int32
+	writeBufferSize   int
+	maxSendMsgSize    int
+	maxRecvMsgSize    int
+	maxHeaderListSize uint32
+}
+
+func newGrpcChannelOptions(config *Config) grpcChannelOptions {
+	return grpcChannelOptions{
+		keepAlive: keepalive.ClientParameters{
+			Time:                time.Duration(config.Int(CfgCollectorGrpcKeepAliveTime)) * time.Millisecond,
+			Timeout:             time.Duration(config.Int(CfgCollectorGrpcKeepAliveTimeout)) * time.Millisecond,
+			PermitWithoutStream: config.Bool(CfgCollectorGrpcKeepAlivePermitWithoutCalls),
+		},
+		flowControlWindow: int32(config.Int(CfgCollectorGrpcFlowControlWindow)),
+		writeBufferSize:   config.Int(CfgCollectorGrpcWriteBufferSize),
+		maxSendMsgSize:    config.Int(CfgCollectorGrpcMaxSendMessageSize),
+		maxRecvMsgSize:    config.Int(CfgCollectorGrpcMaxReceiveMessageSize),
+		maxHeaderListSize: uint32(config.Int(CfgCollectorGrpcMaxHeaderListSize)),
+	}
+}
+
+func (o grpcChannelOptions) dialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithKeepaliveParams(o.keepAlive),
+		grpc.WithInsecure(),
+		grpc.WithInitialWindowSize(o.flowControlWindow),
+		grpc.WithWriteBufferSize(o.writeBufferSize),
+		grpc.WithMaxHeaderListSize(o.maxHeaderListSize),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallSendMsgSize(o.maxSendMsgSize),
+			grpc.MaxCallRecvMsgSize(o.maxRecvMsgSize)),
+	}
 }
 
 func connectCollector(config *Config, portOption string) (*grpc.ClientConn, error) {
-	opts := make([]grpc.DialOption, 0)
-	opts = append(opts, grpc.WithKeepaliveParams(kacp))
-	opts = append(opts, grpc.WithInsecure())
-	opts = append(opts, grpc.WithInitialWindowSize(grpcFlowControlWindow))
-	opts = append(opts, grpc.WithWriteBufferSize(grpcWriteBufferSize))
-	opts = append(opts, grpc.WithMaxHeaderListSize(grpcMaxHeaderListSize))
-	opts = append(opts, grpc.WithDefaultCallOptions(
-		grpc.MaxCallSendMsgSize(grpcMaxMessageSize),
-		grpc.MaxCallRecvMsgSize(grpcMaxMessageSize)))
-
+	opts := newGrpcChannelOptions(config).dialOptions()
 	addr := serverAddr(config, portOption)
 	Log("grpc").Infof("connect to collector: %s", addr)
 	conn, err := grpc.Dial(addr, opts...)

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -699,3 +699,48 @@ func Test_agent_refreshAgentInfoWorker_honorsInterval(t *testing.T) {
 
 	assert.GreaterOrEqual(t, client.calls.Load(), int32(2), "worker must re-send agent info every interval")
 }
+
+// With no Collector.Grpc.* keys set, the channel options must equal the
+// values that were hard-coded before they became configurable, except for
+// PermitWithoutStream, which was deliberately flipped to false to match the
+// C++ agent.
+func Test_grpcChannelOptions_defaults(t *testing.T) {
+	cfg, err := NewConfig(WithAppName("TestApp"))
+	assert.NoError(t, err)
+
+	o := newGrpcChannelOptions(cfg)
+	assert.Equal(t, 30*time.Second, o.keepAlive.Time, "keepalive time")
+	assert.Equal(t, 60*time.Second, o.keepAlive.Timeout, "keepalive timeout")
+	assert.Equal(t, false, o.keepAlive.PermitWithoutStream, "permit without calls")
+	assert.Equal(t, int32(1*1024*1024), o.flowControlWindow, "flow control window")
+	assert.Equal(t, 1*1024*1024, o.writeBufferSize, "write buffer size")
+	assert.Equal(t, 4*1024*1024, o.maxSendMsgSize, "max send message size")
+	assert.Equal(t, 4*1024*1024, o.maxRecvMsgSize, "max receive message size")
+	assert.Equal(t, uint32(8*1024), o.maxHeaderListSize, "max header list size")
+	assert.Len(t, o.dialOptions(), 6)
+}
+
+func Test_grpcChannelOptions_configured(t *testing.T) {
+	cfg, err := NewConfig(
+		WithAppName("TestApp"),
+		WithCollectorGrpcKeepAliveTime(10000),
+		WithCollectorGrpcKeepAliveTimeout(20000),
+		WithCollectorGrpcKeepAlivePermitWithoutCalls(true),
+		WithCollectorGrpcMaxSendMessageSize(8*1024*1024),
+		WithCollectorGrpcMaxReceiveMessageSize(16*1024*1024),
+		WithCollectorGrpcFlowControlWindow(2*1024*1024),
+		WithCollectorGrpcWriteBufferSize(512*1024),
+		WithCollectorGrpcMaxHeaderListSize(16*1024),
+	)
+	assert.NoError(t, err)
+
+	o := newGrpcChannelOptions(cfg)
+	assert.Equal(t, 10*time.Second, o.keepAlive.Time, "keepalive time")
+	assert.Equal(t, 20*time.Second, o.keepAlive.Timeout, "keepalive timeout")
+	assert.Equal(t, true, o.keepAlive.PermitWithoutStream, "permit without calls")
+	assert.Equal(t, int32(2*1024*1024), o.flowControlWindow, "flow control window")
+	assert.Equal(t, 512*1024, o.writeBufferSize, "write buffer size")
+	assert.Equal(t, 8*1024*1024, o.maxSendMsgSize, "max send message size")
+	assert.Equal(t, 16*1024*1024, o.maxRecvMsgSize, "max receive message size")
+	assert.Equal(t, uint32(16*1024), o.maxHeaderListSize, "max header list size")
+}


### PR DESCRIPTION
Fixes #162

## What

The gRPC channel options were source constants in `grpc.go`, so tuning keepalive for a proxied or load-balanced collector required rebuilding the agent. They are now configuration keys under `Collector.Grpc.*`, read by `connectCollector()` when it builds the `DialOption`s.

| Key | Type | Default | Note |
|---|---|---|---|
| `Collector.Grpc.KeepAliveTime` | int (ms) | `30000` | |
| `Collector.Grpc.KeepAliveTimeout` | int (ms) | `60000` | |
| `Collector.Grpc.KeepAlivePermitWithoutCalls` | bool | `false` | **behavior change** — see below |
| `Collector.Grpc.MaxSendMessageSize` | int | `4194304` | split from the single shared constant |
| `Collector.Grpc.MaxReceiveMessageSize` | int | `4194304` | split from the single shared constant |
| `Collector.Grpc.FlowControlWindow` | int | `1048576` | no C++ equivalent |
| `Collector.Grpc.WriteBufferSize` | int | `1048576` | no C++ equivalent |
| `Collector.Grpc.MaxHeaderListSize` | int | `8192` | no C++ equivalent |

Command-line flags, environment variables and `With...()` functions follow the existing config conventions.

## Naming

Key names follow the C++ agent's `Collector.Grpc.*` semantics, with the `Ms` suffix dropped (`KeepAliveTimeMs` -> `KeepAliveTime`) because the existing Go millisecond keys carry no unit suffix (`Stat.CollectInterval`, `Span.BatchFlushInterval`); the values are still milliseconds. `KeepAlivePermitWithoutCalls` keeps the C++ key name rather than the grpc-go field name (`PermitWithoutStream`) so the two agents' configuration is cross-searchable.

C++'s `SenderQueueSize` is intentionally not ported: the Go span queue is already configurable via `Span.QueueSize`, and Go metadata requests are synchronous unary RPCs with no sender queue to size.

## Behavior change: keepalive on idle connections

Every default reproduces the previous constant exactly, **except** `KeepAlivePermitWithoutCalls`. The Go agent used to set `PermitWithoutStream: true` unconditionally, pinging idle connections; the C++ agent leaves the equivalent option off. The default is now `false` so both agents put the same idle keepalive load on the collector. Deployments that relied on the old behavior can set the key back to `true`.

One consequence is worth knowing before merging. Of the four collector connections, three keep a long-lived stream open (agent — ping stream, shared with metadata; command; stat) and so keep pinging regardless. The span connection does not: with `Span.Batch.Enable` on (the default) spans are sent as unary `SendSpanBatch` requests, so while the application is idle the span connection has no active stream and now sends no keepalive pings at all. If an intermediary drops that idle connection, the agent will not notice until the next batch. The C++ agent does not have this gap because its span channel is stream-based.

Making this per-channel was considered and skipped — it would split one key into four, and the config knob covers the case for anyone who hits it.

## Tests

- `Test_grpcChannelOptions_defaults` — with no keys set, the resolved options equal the previously hard-coded values, with `PermitWithoutStream` asserted at its new `false`.
- `Test_grpcChannelOptions_configured` — configured values reach the options used to build the `DialOption`s.

`go test -race ./...` passes.
