### PR TITLE
[#163] Let the collector channels dial TLS instead of always insecure

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,6 +40,8 @@ const (
 	CfgCollectorGrpcFlowControlWindow           = "Collector.Grpc.FlowControlWindow"
 	CfgCollectorGrpcWriteBufferSize             = "Collector.Grpc.WriteBufferSize"
 	CfgCollectorGrpcMaxHeaderListSize           = "Collector.Grpc.MaxHeaderListSize"
+	CfgCollectorGrpcSslEnable                   = "Collector.Grpc.SslEnable"
+	CfgCollectorGrpcTrustCertFilePath           = "Collector.Grpc.TrustCertFilePath"
 
 	CfgLogLevelOld                    = "LogLevel"
 	CfgLogLevel                       = "Log.Level"
@@ -131,6 +133,8 @@ func initConfig() {
 	AddConfig(CfgCollectorGrpcFlowControlWindow, CfgInt, grpcFlowControlWindow, false)
 	AddConfig(CfgCollectorGrpcWriteBufferSize, CfgInt, grpcWriteBufferSize, false)
 	AddConfig(CfgCollectorGrpcMaxHeaderListSize, CfgInt, grpcMaxHeaderListSize, false)
+	AddConfig(CfgCollectorGrpcSslEnable, CfgBool, false, false)
+	AddConfig(CfgCollectorGrpcTrustCertFilePath, CfgString, "", false)
 	AddConfig(CfgLogLevelOld, CfgString, "info", true)
 	AddConfig(CfgLogLevel, CfgString, "info", true)
 	AddConfig(CfgLogOutput, CfgString, "stderr", true)
@@ -917,6 +921,22 @@ func WithCollectorGrpcWriteBufferSize(size int) ConfigOption {
 func WithCollectorGrpcMaxHeaderListSize(size int) ConfigOption {
 	return func(c *Config) {
 		c.cfgMap[CfgCollectorGrpcMaxHeaderListSize].value = size
+	}
+}
+
+// WithCollectorGrpcSslEnable enables TLS on the gRPC channels to pinpoint collector.
+func WithCollectorGrpcSslEnable(enable bool) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcSslEnable].value = enable
+	}
+}
+
+// WithCollectorGrpcTrustCertFilePath sets the PEM certificate used as the trust
+// root when verifying the collector's TLS certificate.
+// If not set, the system root CAs are used.
+func WithCollectorGrpcTrustCertFilePath(path string) ConfigOption {
+	return func(c *Config) {
+		c.cfgMap[CfgCollectorGrpcTrustCertFilePath].value = path
 	}
 }
 

--- a/doc/config.md
+++ b/doc/config.md
@@ -361,6 +361,33 @@ Collector.Grpc.MaxHeaderListSize option sets the max size in bytes of gRPC respo
 * int
 * default: 8192
 
+### Collector.Grpc.SslEnable
+Collector.Grpc.SslEnable option enables TLS on all gRPC channels
+(agent, metadata, span, stat) to Pinpoint collector.
+When disabled (default), the agent connects in plaintext as before.
+
+* --pinpoint-collector-grpc-sslenable
+* PINPOINT_GO_COLLECTOR_GRPC_SSLENABLE
+* WithCollectorGrpcSslEnable()
+* bool
+* default: false
+
+### Collector.Grpc.TrustCertFilePath
+Collector.Grpc.TrustCertFilePath option sets the path of a PEM certificate
+used as the trust root when verifying the collector's TLS certificate.
+If it is not set, the system root CAs are used.
+If the file cannot be read or is not a valid certificate, the agent logs an
+error and fails the collector connection instead of falling back to plaintext,
+so the agent stays disabled.
+It is ignored unless [Collector.Grpc.SslEnable](#collectorgrpcsslenable) is enabled.
+
+* --pinpoint-collector-grpc-trustcertfilepath
+* PINPOINT_GO_COLLECTOR_GRPC_TRUSTCERTFILEPATH
+* WithCollectorGrpcTrustCertFilePath()
+* string
+* default: ""
+* case-sensitive
+
 ### Sampling.Type
 Sampling.Type option sets the type of agent sampler.
 Either "COUNTER" or "PERCENT" must be specified.

--- a/grpc.go
+++ b/grpc.go
@@ -2,6 +2,7 @@ package pinpoint
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"math"
 	"math/rand"
@@ -20,6 +21,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -203,10 +206,10 @@ func newGrpcChannelOptions(config *Config) grpcChannelOptions {
 	}
 }
 
-func (o grpcChannelOptions) dialOptions() []grpc.DialOption {
+func (o grpcChannelOptions) dialOptions(creds credentials.TransportCredentials) []grpc.DialOption {
 	return []grpc.DialOption{
 		grpc.WithKeepaliveParams(o.keepAlive),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(creds),
 		grpc.WithInitialWindowSize(o.flowControlWindow),
 		grpc.WithWriteBufferSize(o.writeBufferSize),
 		grpc.WithMaxHeaderListSize(o.maxHeaderListSize),
@@ -216,10 +219,37 @@ func (o grpcChannelOptions) dialOptions() []grpc.DialOption {
 	}
 }
 
+// collectorCredentials mirrors the C++ agent's make_channel_credentials:
+// TLS disabled is insecure, a configured trust cert path is the trust root,
+// and an empty path with TLS enabled falls back to the system root CAs. An
+// unreadable or invalid cert is an error, never a silent insecure downgrade.
+func collectorCredentials(config *Config) (credentials.TransportCredentials, error) {
+	if !config.Bool(CfgCollectorGrpcSslEnable) {
+		return insecure.NewCredentials(), nil
+	}
+
+	certPath := config.String(CfgCollectorGrpcTrustCertFilePath)
+	if certPath == "" {
+		return credentials.NewTLS(&tls.Config{}), nil
+	}
+
+	creds, err := credentials.NewClientTLSFromFile(certPath, "")
+	if err != nil {
+		return nil, fmt.Errorf("gRPC TLS trust certificate %s: %w", certPath, err)
+	}
+	return creds, nil
+}
+
 func connectCollector(config *Config, portOption string) (*grpc.ClientConn, error) {
-	opts := newGrpcChannelOptions(config).dialOptions()
+	creds, err := collectorCredentials(config)
+	if err != nil {
+		Log("grpc").Errorf("collector TLS credentials - %v", err)
+		return nil, err
+	}
+
+	opts := newGrpcChannelOptions(config).dialOptions(creds)
 	addr := serverAddr(config, portOption)
-	Log("grpc").Infof("connect to collector: %s", addr)
+	Log("grpc").Infof("connect to collector: %s (ssl: %v)", addr, config.Bool(CfgCollectorGrpcSslEnable))
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {
 		Log("grpc").Errorf("connect to collector - %s, %v", addr, err)

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 )
 
@@ -485,7 +486,7 @@ func Test_backOffUntilReady_abortsOnShutdown(t *testing.T) {
 	agent := newTestAgent(defaultConfig())
 	// Port 1 has no listener, so this connection never becomes ready and the
 	// back-off loop keeps waiting until it is told to stop.
-	conn, err := grpc.Dial("127.0.0.1:1", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:1", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.NoError(t, err)
 	defer conn.Close()
 
@@ -534,7 +535,7 @@ func Test_backOffSleep_rampsGentlyToCeiling(t *testing.T) {
 func Test_waitUntilReady_connectsIdleChannel(t *testing.T) {
 	// NewClient, not Dial: it leaves the channel IDLE instead of connecting
 	// eagerly, which is the state this path exists for.
-	conn, err := grpc.NewClient("127.0.0.1:1", grpc.WithInsecure())
+	conn, err := grpc.NewClient("127.0.0.1:1", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	assert.NoError(t, err)
 	defer conn.Close()
 
@@ -717,7 +718,7 @@ func Test_grpcChannelOptions_defaults(t *testing.T) {
 	assert.Equal(t, 4*1024*1024, o.maxSendMsgSize, "max send message size")
 	assert.Equal(t, 4*1024*1024, o.maxRecvMsgSize, "max receive message size")
 	assert.Equal(t, uint32(8*1024), o.maxHeaderListSize, "max header list size")
-	assert.Len(t, o.dialOptions(), 6)
+	assert.Len(t, o.dialOptions(insecure.NewCredentials()), 6)
 }
 
 func Test_grpcChannelOptions_configured(t *testing.T) {

--- a/grpc_tls_test.go
+++ b/grpc_tls_test.go
@@ -1,0 +1,140 @@
+package pinpoint
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+)
+
+// genTestCert writes a self-signed cert/key pair for 127.0.0.1 into dir.
+func genTestCert(t *testing.T, dir string) (certFile, keyFile string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	assert.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "pinpoint-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	assert.NoError(t, err)
+	keyDer, err := x509.MarshalECPrivateKey(key)
+	assert.NoError(t, err)
+
+	certFile = filepath.Join(dir, "cert.pem")
+	keyFile = filepath.Join(dir, "key.pem")
+	assert.NoError(t, os.WriteFile(certFile,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0600))
+	assert.NoError(t, os.WriteFile(keyFile,
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDer}), 0600))
+	return certFile, keyFile
+}
+
+// startTLSCollector serves gRPC over TLS on 127.0.0.1 with a self-signed cert
+// and returns the port and the cert to trust.
+func startTLSCollector(t *testing.T) (port int, certFile string) {
+	t.Helper()
+
+	certFile, keyFile := genTestCert(t, t.TempDir())
+	creds, err := credentials.NewServerTLSFromFile(certFile, keyFile)
+	assert.NoError(t, err)
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+
+	srv := grpc.NewServer(grpc.Creds(creds))
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+	return lis.Addr().(*net.TCPAddr).Port, certFile
+}
+
+func tlsTestConfig(t *testing.T, port int, opts ...ConfigOption) *Config {
+	t.Helper()
+	c, err := NewConfig(append([]ConfigOption{
+		WithAppName("test"),
+		WithAgentId("testagent"),
+		WithCollectorHost("127.0.0.1"),
+		WithCollectorAgentPort(port),
+	}, opts...)...)
+	assert.NoError(t, err)
+	return c
+}
+
+func Test_connectCollector_tlsHandshake(t *testing.T) {
+	port, certFile := startTLSCollector(t)
+	c := tlsTestConfig(t, port,
+		WithCollectorGrpcSslEnable(true),
+		WithCollectorGrpcTrustCertFilePath(certFile))
+
+	conn, err := connectCollector(c, CfgCollectorAgentPort)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	assert.True(t, waitUntilReady(context.Background(), conn, 5*time.Second, "tls-test"))
+}
+
+func Test_connectCollector_tlsRejectsUntrustedServer(t *testing.T) {
+	port, _ := startTLSCollector(t)
+	// Trust a cert the server does not use: verification must fail, so the
+	// channel never becomes ready.
+	otherCert, _ := genTestCert(t, t.TempDir())
+	c := tlsTestConfig(t, port,
+		WithCollectorGrpcSslEnable(true),
+		WithCollectorGrpcTrustCertFilePath(otherCert))
+
+	conn, err := connectCollector(c, CfgCollectorAgentPort)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	assert.False(t, waitUntilReady(context.Background(), conn, 2*time.Second, "tls-test"))
+}
+
+func Test_connectCollector_badTrustCertFailsLoud(t *testing.T) {
+	garbage := filepath.Join(t.TempDir(), "garbage.pem")
+	assert.NoError(t, os.WriteFile(garbage, []byte("not a certificate"), 0600))
+
+	for _, certPath := range []string{"/nonexistent/ca.pem", garbage} {
+		c := tlsTestConfig(t, 9991,
+			WithCollectorGrpcSslEnable(true),
+			WithCollectorGrpcTrustCertFilePath(certPath))
+
+		conn, err := connectCollector(c, CfgCollectorAgentPort)
+		assert.Error(t, err, certPath)
+		assert.Nil(t, conn, certPath)
+	}
+}
+
+func Test_connectCollector_defaultInsecure(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	assert.NoError(t, err)
+	srv := grpc.NewServer()
+	go srv.Serve(lis)
+	t.Cleanup(srv.Stop)
+
+	c := tlsTestConfig(t, lis.Addr().(*net.TCPAddr).Port)
+	assert.False(t, c.Bool(CfgCollectorGrpcSslEnable))
+
+	conn, err := connectCollector(c, CfgCollectorAgentPort)
+	assert.NoError(t, err)
+	defer conn.Close()
+
+	assert.True(t, waitUntilReady(context.Background(), conn, 5*time.Second, "plaintext-test"))
+}


### PR DESCRIPTION
Fixes #163.

`connectCollector` appended `grpc.WithInsecure()` unconditionally, so a
collector exposed over TLS had no way to accept this agent. All five dial
sites (agent, metadata, span, stat, command) route through that one
function, so one credential choice covers every channel.

## Changes

- **`Collector.Grpc.SslEnable`** (bool, default `false`) — enables TLS on the
  collector channels.
- **`Collector.Grpc.TrustCertFilePath`** (string, default `""`) — PEM trust
  root for verifying the collector certificate; empty means system root CAs.
- `collectorCredentials` picks the credentials; `grpc.WithInsecure()` is
  replaced with `WithTransportCredentials(insecure.NewCredentials())` (the
  deprecated call is also cleaned up at the two test call sites).
- doc/config.md documents both options.

## Matching the C++ agent

`collectorCredentials` mirrors `make_channel_credentials` in
pinpoint-cpp-agent `src/grpc.cpp`:

| | C++ | Go (this PR) |
|---|---|---|
| SSL disabled | `InsecureChannelCredentials()` | `insecure.NewCredentials()` |
| SSL on, cert path set | PEM loaded as `pem_root_certs` | `credentials.NewClientTLSFromFile(path, "")` |
| SSL on, no cert path | gRPC default (system) root CAs | `credentials.NewTLS(&tls.Config{})` — system root CAs |
| Bad cert file | throws, no downgrade | error, no downgrade |

Server name verification uses the dial host on both sides; neither overrides
it. One deliberate difference: the C++ `RootCertFilePath` alias is not carried
over — it exists there for legacy config compatibility, and this is new
surface. Easy to add if wanted.

## No silent downgrade

An unreadable or unparseable trust certificate is an error, never a fallback
to plaintext: `connectCollector` logs it and returns, and `connectGrpcServer`'s
existing early return leaves the agent disabled (application behavior
unaffected). A cert that fails verification surfaces on the first RPC, where
`registerAgentWithRetry` already backs off with the agent still disabled.

## Compatibility

Default is disabled, so existing deployments dial exactly as before. A test
pins that.

## Tests

New `grpc_tls_test.go` brings up a TLS gRPC server on a self-signed cert:

- handshake reaches READY with that cert as the trust root
- a *different* trust cert leaves the channel short of READY — pins that
  verification is actually performed, so an `InsecureSkipVerify`-style
  regression fails the suite
- a missing path and a malformed PEM both return an error instead of passing
  quietly
- default config still connects to a plaintext server

`go test -race ./...` passes; `go vet` is clean.
