### PR TITLE
[#129] Fix shutdown worker signaling

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -56,9 +56,9 @@ type agent struct {
 	shutdown  atomic.Bool
 
 	// stopCtx is cancelled when shutdown begins. The shutdown flag above is
-	// only polled, so it cannot wake a goroutine already blocked in a
-	// reconnect wait; the context can. Created lazily because the agent is
-	// built as a struct literal in several places, including test helpers.
+	// only polled, so it cannot wake a goroutine already blocked in a wait;
+	// the context can. NewAgent creates it before starting goroutines, while
+	// stopOnce also supports agents built as struct literals in tests.
 	stopOnce   sync.Once
 	stopCtx    context.Context
 	stopCancel context.CancelFunc
@@ -68,13 +68,6 @@ type agent struct {
 	// it instead of rebuilding the metadata map on every request.
 	grpcMetaOnce sync.Once
 	grpcMetaCtx  context.Context
-
-	pingTicker    *time.Ticker
-	pingDone      chan bool
-	statTicker    *time.Ticker
-	statDone      chan bool
-	urlStatTicker *time.Ticker
-	urlStatDone   chan bool
 }
 
 type apiMeta struct {
@@ -187,6 +180,7 @@ func NewAgent(config *Config) (Agent, error) {
 		statChan:    make(chan *pb.PStatMessage, config.Int(CfgSpanQueueSize)),
 		config:      config,
 	}
+	agent.stopSignal()
 
 	agent.errorCache = newMetaCache[string, int32](cacheSize, hashStringKey)
 	agent.sqlCache = newMetaCache[string, int32](cacheSize, hashStringKey)
@@ -309,14 +303,6 @@ func (agent *agent) Shutdown() {
 		agent.cmdGrpc.close()
 	}
 
-	if !agent.config.offGrpc {
-		agent.pingTicker.Stop()
-		agent.pingDone <- true
-		agent.statTicker.Stop()
-		agent.statDone <- true
-		agent.urlStatTicker.Stop()
-		agent.urlStatDone <- true
-	}
 	// Bound the drain: a collector outage must not keep the process alive.
 	// Abandoned workers are unblocked by the connection close below.
 	if !waitTimeout(&agent.workerWg, shutdownTimeout) {
@@ -396,8 +382,9 @@ func (agent *agent) sendPingWorker() {
 	Log("agent").Infof("start ping goroutine")
 	defer agent.workerWg.Done()
 
-	agent.pingTicker = time.NewTicker(60 * time.Second)
-	agent.pingDone = make(chan bool)
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	stop := agent.stopSignal().Done()
 	stream := agent.agentGrpc.newPingStreamWithRetry()
 
 	for agent.enable.Load() {
@@ -412,11 +399,11 @@ func (agent *agent) sendPingWorker() {
 		}
 
 		select {
-		case <-agent.pingDone:
+		case <-stop:
 			Log("agent").Infof("end ping goroutine")
 			stream.close()
 			return
-		case t := <-agent.pingTicker.C:
+		case t := <-ticker.C:
 			if IsDebugLogLevelEnabled() {
 				Log("agent").Debugf("ping at", t)
 			}
@@ -752,15 +739,16 @@ func (agent *agent) sendUrlStatWorker() {
 	Log("agent").Infof("start send uri stat goroutine")
 	defer agent.workerWg.Done()
 
-	agent.urlStatTicker = time.NewTicker(30 * time.Second)
-	agent.urlStatDone = make(chan bool)
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	stop := agent.stopSignal().Done()
 
 	for agent.enable.Load() {
 		select {
-		case <-agent.urlStatDone:
+		case <-stop:
 			Log("agent").Infof("end send uri stat goroutine")
 			return
-		case <-agent.urlStatTicker.C:
+		case <-ticker.C:
 			if agent.config.load().collectUrlStat {
 				snapshot := agent.takeUrlStatSnapshot()
 				agent.enqueueStat(makePAgentUriStat(snapshot))

--- a/agent_test.go
+++ b/agent_test.go
@@ -246,6 +246,36 @@ func Test_waitTimeout(t *testing.T) {
 	assert.True(t, waitTimeout(&wg, time.Second), "done before the deadline")
 }
 
+// Shutdown must not wait for a Done receiver after a ticker worker has already
+// observed enable=false and exited.
+func Test_agent_ShutdownAfterPingWorkerExited(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	agent.agentGrpc = &agentGrpc{agent: agent}
+	agent.statChan = make(chan *pb.PStatMessage)
+	agent.urlStatChan = make(chan *urlStat)
+
+	agent.enable.Store(false)
+	agent.workerWg.Add(1)
+	go agent.sendPingWorker()
+	if !waitTimeout(&agent.workerWg, time.Second) {
+		t.Fatal("ping worker did not exit")
+	}
+
+	agent.config.offGrpc = false
+	agent.enable.Store(true)
+	done := make(chan struct{})
+	go func() {
+		agent.Shutdown()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Shutdown blocked signaling an exited worker")
+	}
+}
+
 // A worker stuck on an unreachable collector must not hold Shutdown forever.
 func Test_agent_ShutdownDeadline(t *testing.T) {
 	opts := []ConfigOption{

--- a/stats.go
+++ b/stats.go
@@ -304,8 +304,9 @@ func (agent *agent) collectAgentStatWorker() {
 	resetResponseTime()
 
 	interval := time.Duration(agent.config.Int(CfgStatCollectInterval)) * time.Millisecond
-	agent.statTicker = time.NewTicker(interval)
-	agent.statDone = make(chan bool)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	stop := agent.stopSignal().Done()
 
 	cfgBatchCount := agent.config.Int(CfgStatBatchCount)
 	collected := make([]*inspectorStats, cfgBatchCount)
@@ -313,10 +314,10 @@ func (agent *agent) collectAgentStatWorker() {
 
 	for agent.enable.Load() {
 		select {
-		case <-agent.statDone:
+		case <-stop:
 			Log("stats").Infof("end collect agent stat goroutine")
 			return
-		case <-agent.statTicker.C:
+		case <-ticker.C:
 			collected[batch] = getStats()
 			batch++
 


### PR DESCRIPTION
## Summary

- reuse the shared shutdown cancellation signal for ping, agent-stat, and URL-stat workers
- keep ticker creation and cleanup inside each owning worker
- remove blocking per-worker shutdown sends and add a deterministic exited-worker regression test

## Testing

- go test . -count=1
- go test -race . -count=1

Refs #129