### PR TITLE
[#129] Wait for stream timeout cancellation callback

### DIFF
--- a/grpc.go
+++ b/grpc.go
@@ -561,18 +561,22 @@ func makePStackTraceElementList(frames []frame) []*pb.PStackTraceElement {
 
 // sendStreamWithTimeout runs op on the calling goroutine and cancels the
 // stream if op blocks past timeout. grpc-go unblocks a flow-control-blocked
-// Send/Recv/CloseSend once the stream context is cancelled, so nothing is
-// spawned or abandoned — the Go analog of the C++ agent's bounded wait plus
-// TryCancel. Killing the stream on timeout matches the callers: they already
-// close and re-create the stream on any send error.
+// Send/Recv/CloseSend once the stream context is cancelled, so no operation
+// goroutine is spawned or abandoned — the Go analog of the C++ agent's bounded
+// wait plus TryCancel. Killing the stream on timeout matches the callers: they
+// already close and re-create the stream on any send error.
 func sendStreamWithTimeout(op func() error, cancelStream context.CancelFunc, timeout time.Duration, which string) error {
 	var timedOut atomic.Bool
+	callbackDone := make(chan struct{})
 	t := time.AfterFunc(timeout, func() {
-		timedOut.Store(true)
+		defer close(callbackDone)
 		cancelStream()
+		timedOut.Store(true)
 	})
 	err := op()
-	t.Stop()
+	if !t.Stop() {
+		<-callbackDone
+	}
 	if timedOut.Load() {
 		return status.Errorf(codes.DeadlineExceeded, which+" - too slow or blocked")
 	}

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -488,6 +488,53 @@ func Test_sendStreamWithTimeout_passesThroughResult(t *testing.T) {
 	assert.Equal(t, sendErr, sendStreamWithTimeout(func() error { return sendErr }, func() {}, time.Second, "test"))
 }
 
+func Test_sendStreamWithTimeout_waitsForStartedCallback(t *testing.T) {
+	// Force Stop to lose to the timer while cancelStream is still running.
+	// The helper must join that callback instead of letting cancellation escape.
+	cancelStarted := make(chan struct{})
+	finishCancel := make(chan struct{})
+	cancelFinished := make(chan struct{})
+	result := make(chan error, 1)
+	var finishOnce sync.Once
+	finish := func() { finishOnce.Do(func() { close(finishCancel) }) }
+	defer finish()
+
+	go func() {
+		result <- sendStreamWithTimeout(
+			func() error {
+				<-cancelStarted
+				return nil
+			},
+			func() {
+				close(cancelStarted)
+				<-finishCancel
+				close(cancelFinished)
+			},
+			0, "test stream.Send()",
+		)
+	}()
+
+	<-cancelStarted
+	select {
+	case err := <-result:
+		t.Fatalf("returned %v while the cancellation callback was still running", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	finish()
+	select {
+	case err := <-result:
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+		select {
+		case <-cancelFinished:
+		default:
+			t.Fatal("returned before the cancellation callback completed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("did not return after the cancellation callback completed")
+	}
+}
+
 // An unresponsive stream: Send blocks until the stream context is cancelled,
 // which is how a grpc-go Send stuck on flow control behaves. The wrapper must
 // unblock it via cancel and, running the send on the calling goroutine, leave
@@ -507,8 +554,8 @@ func Test_sendStreamWithTimeout_unresponsiveStreamLeaksNothing(t *testing.T) {
 		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 	}
 
-	// Allow the fired AfterFunc callbacks to finish; they are the only
-	// transient goroutines this path may create.
+	// Fired AfterFunc callbacks are joined before each call returns; give any
+	// unrelated runtime cleanup a moment to settle before comparing.
 	deadline := time.Now().Add(time.Second)
 	for runtime.NumGoroutine() > before && time.Now().Before(deadline) {
 		time.Sleep(5 * time.Millisecond)


### PR DESCRIPTION
## Summary

- wait for a started time.AfterFunc callback when Timer.Stop reports false
- prevent cancellation from escaping sendStreamWithTimeout after it returns, without spawning an operation goroutine
- add deterministic callback-completion coverage while preserving DeadlineExceeded behavior

## Validation

- go test . -count=1
- go test -race . -count=1
- focused timeout tests: 20 normal runs and 5 race-detector runs
- existing ping, stat, and span timeout integration tests individually

Related to #129