### PR TITLE
[#153] Use full span queue capacity before dropping

### DIFF
--- a/span_queue.go
+++ b/span_queue.go
@@ -92,8 +92,8 @@ func newSpanQueue(capacity int) *spanQueue {
 
 // enqueue never blocks and, until close, never rejects: a full shard head-drops
 // its oldest chunk in the same critical section, so recent traces are favored
-// under backpressure. Trying a second shard first keeps a momentarily full
-// shard from dropping while the queue as a whole still has room.
+// under backpressure. A full first-choice shard triggers a scan; overwrite is
+// used only after every shard reports full.
 func (q *spanQueue) enqueue(chunk *spanChunk) bool {
 	if q.closed.Load() {
 		return false
@@ -104,12 +104,14 @@ func (q *spanQueue) enqueue(chunk *spanChunk) bool {
 		q.notify()
 		return true
 	}
-	second := rand.IntN(len(q.shards))
-	if second != first && q.shards[second].tryEnqueue(chunk) {
-		q.notify()
-		return true
+	for i := 1; i < len(q.shards); i++ {
+		shard := (first + i) % len(q.shards)
+		if q.shards[shard].tryEnqueue(chunk) {
+			q.notify()
+			return true
+		}
 	}
-	q.shards[second].enqueueOrOverwrite(chunk)
+	q.shards[first].enqueueOrOverwrite(chunk)
 	q.notify()
 	return true
 }

--- a/span_queue_test.go
+++ b/span_queue_test.go
@@ -37,14 +37,16 @@ func Test_spanQueue_singleProducerUsesFullCapacity(t *testing.T) {
 	agent := newTestAgent(defaultConfig())
 	chunk := newTestSpanChunk(agent)
 
-	enqueued := 20 * capacity // enough for random placement to hit every shard
-	for i := 0; i < enqueued; i++ {
+	for i := 0; i < capacity; i++ {
 		assert.True(t, q.enqueue(chunk))
 	}
 
 	assert.Equal(t, capacity, q.length(), "retained spans must fill the whole buffer")
-	assert.Equal(t, int64(enqueued-capacity), q.dropCount(),
-		"every enqueue beyond capacity is a counted drop")
+	assert.Zero(t, q.dropCount(), "filling the configured capacity must not drop spans")
+
+	assert.True(t, q.enqueue(chunk))
+	assert.Equal(t, capacity, q.length(), "the queue must remain bounded after saturation")
+	assert.Equal(t, int64(1), q.dropCount(), "an enqueue beyond capacity must count one drop")
 }
 
 func Test_spanQueue_closeRejectsEnqueueAndReportsDone(t *testing.T) {


### PR DESCRIPTION
## Summary

- scan remaining span queue shards before overwriting a full shard
- preserve bounded capacity and existing drop accounting
- regress exactly 1024 enqueues with zero premature drops

## Validation

- go test ./...
- go test -race .
- go vet ./...
- focused enqueue benchmarks with zero allocations