### PR TITLE
[#122] Enforce segment boundaries for Ant double-star slash

### DIFF
--- a/plugin/http/url.go
+++ b/plugin/http/url.go
@@ -23,7 +23,7 @@ const (
 	tokenLiteral         tokenKind = iota
 	tokenStar                      // '*'  - zero or more characters within one path segment
 	tokenDoubleStar                // '**' - zero or more characters across path segments
-	tokenDoubleStarSlash           // '**/' - like '**', but only while URL input remains
+	tokenDoubleStarSlash           // '**/' - zero or more whole path segments
 	tokenQuestion                  // '?'  - exactly one character, never the path separator
 )
 
@@ -153,13 +153,21 @@ func (h *httpExcludeUrl) antMatch(urlPath string) bool {
 			for j := u - 1; j >= 0; j-- {
 				cur[j] = next[j] || (urlPath[j] != '/' && cur[j+1])
 			}
-		case tokenDoubleStar, tokenDoubleStarSlash:
-			// '**/' may skip the separator, but only while URL input remains.
-			cur[u] = t.kind == tokenDoubleStar && next[u]
+		case tokenDoubleStar:
+			cur[u] = next[u]
 			running := next[u]
 			for j := u - 1; j >= 0; j-- {
 				running = running || next[j]
 				cur[j] = running
+			}
+		case tokenDoubleStarSlash:
+			cur[u] = next[u]
+			running := false
+			for j := u - 1; j >= 0; j-- {
+				if urlPath[j] == '/' {
+					running = running || next[j+1]
+				}
+				cur[j] = next[j] || running
 			}
 		}
 		cur, next = next, cur

--- a/plugin/http/url_test.go
+++ b/plugin/http/url_test.go
@@ -79,7 +79,13 @@ func TestHttpExcludeUrlMatch(t *testing.T) {
 				"/aa/bb/index.html",
 				"/aa/bb/cc/index.html",
 			},
-			noMatch: []string{"/aa/index.htm", "/bb/index.html", "/aaindex.html"},
+			noMatch: []string{
+				"/aa/index.htm",
+				"/bb/index.html",
+				"/aaindex.html",
+				"/aa/not-index.html",
+				"/aa/fooindex.html",
+			},
 		},
 		{
 			name:    "leading ** spans segments",


### PR DESCRIPTION
## Summary
- require Ant `**/` matches to transition only at slash boundaries
- preserve zero-segment and nested-segment matches
- cover the `/aa/not-index.html` and `/aa/fooindex.html` regressions

## Testing
- `go test . -count=1` in `plugin/http`

Closes #122