### PR TITLE
[#164] Cap concurrent active thread count streams

### DIFF
--- a/command.go
+++ b/command.go
@@ -8,10 +8,80 @@ import (
 	"time"
 )
 
+const (
+	// maxActiveThreadCountStreams caps the active thread count streams running
+	// at once. Every ACTIVE_THREAD_COUNT command costs a goroutine and a gRPC
+	// stream, and the web UI re-requests one whenever a user opens the
+	// real-time view, so without a cap a re-request loop grows both without
+	// bound. Deliberately a constant, not a config key: the C++ agent keeps the
+	// same value as a tuning constant, and 10 concurrent real-time viewers of a
+	// single agent is already well past what the UI produces.
+	maxActiveThreadCountStreams = 10
+
+	// activeThreadCountInterval is how long a stream waits between samples.
+	activeThreadCountInterval = 1 * time.Second
+)
+
 var (
 	gAtcStreamCount    int32
 	realTimeActiveSpan sync.Map
 )
+
+// atcStreams holds the running active thread count streams, so a re-issued
+// request id can reclaim its predecessor and so the total can be capped.
+type atcStreams struct {
+	mu      sync.Mutex
+	streams map[*activeThreadCountStream]struct{}
+}
+
+// add registers s and reports whether it may run. Streams are keyed by identity
+// rather than by request id: a predecessor that has been told to stop stays
+// registered until its goroutine returns, so it keeps counting against the cap
+// and a re-request loop cannot outrun the teardown.
+func (r *atcStreams) add(s *activeThreadCountStream) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// The collector re-issues a command for a request id it already owns, e.g.
+	// after a command stream reconnect. Signal the predecessor to stop; it
+	// removes itself once its goroutine returns.
+	for old := range r.streams {
+		if old.reqId == s.reqId {
+			old.requestStop()
+		}
+	}
+
+	if len(r.streams) >= maxActiveThreadCountStreams {
+		return false
+	}
+	if r.streams == nil {
+		r.streams = make(map[*activeThreadCountStream]struct{})
+	}
+	r.streams[s] = struct{}{}
+	r.publishCount()
+	return true
+}
+
+func (r *atcStreams) remove(s *activeThreadCountStream) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.streams, s)
+	r.publishCount()
+}
+
+func (r *atcStreams) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.streams)
+}
+
+// publishCount republishes the stream count for addRealTime*ActiveSpan, which
+// reads it on every span start and cannot afford to take this lock. Callers
+// must hold r.mu.
+func (r *atcStreams) publishCount() {
+	atomic.StoreInt32(&gAtcStreamCount, int32(len(r.streams)))
+}
 
 type activeSpanInfo struct {
 	startTime  time.Time
@@ -23,7 +93,6 @@ type activeSpanInfo struct {
 func (agent *agent) runCommandService() {
 	Log("cmd").Infof("start command goroutine")
 	defer agent.workerWg.Done()
-	gAtcStreamCount = 0
 
 	for agent.enable.Load() {
 		stream := agent.cmdGrpc.newCommandStreamWithRetry()
@@ -54,8 +123,7 @@ func (agent *agent) runCommandService() {
 				agent.cmdGrpc.sendEcho(reqId, msg)
 				break
 			case *pb.PCmdRequest_CommandActiveThreadCount:
-				atcStream := agent.cmdGrpc.newActiveThreadCountStream(reqId)
-				go agent.sendActiveThreadCount(atcStream)
+				agent.handleActiveThreadCount(reqId, stream)
 				break
 			case *pb.PCmdRequest_CommandActiveThreadDump:
 				if c := cmdReq.GetCommandActiveThreadDump(); c != nil {
@@ -82,28 +150,67 @@ func (agent *agent) runCommandService() {
 	Log("cmd").Infof("end command goroutine")
 }
 
-func (agent *agent) sendActiveThreadCount(s *activeThreadCountStream) {
-	atomic.AddInt32(&gAtcStreamCount, 1)
-	Log("cmd").Infof("active thread count stream goroutine start: %d, %d", s.reqId, gAtcStreamCount)
+// handleActiveThreadCount starts an active thread count stream for reqId, or
+// rejects the request when maxActiveThreadCountStreams are already running.
+// Mirrors the C++ agent's handle_active_thread_count().
+func (agent *agent) handleActiveThreadCount(reqId int32, cmd *cmdStream) {
+	s := newActiveThreadCountStream(reqId)
 
-	for agent.enable.Load() {
+	// Register before opening the gRPC stream: the cap and the stop of a
+	// same-id predecessor are then decided under a single lock, and a request
+	// that the cap rejects never opens a stream at all.
+	if !agent.cmdGrpc.atcStreams.add(s) {
+		Log("cmd").Warnf("reject active thread count stream: %d, %d", reqId, agent.cmdGrpc.atcStreams.count())
+		if err := cmd.sendFailMessage(reqId, "too many active thread count streams"); err != nil {
+			Log("cmd").Errorf("send fail message - %d, %v", reqId, err)
+		}
+		return
+	}
+
+	if !agent.cmdGrpc.openActiveThreadCountStream(s) {
+		agent.cmdGrpc.atcStreams.remove(s)
+		return
+	}
+
+	go agent.sendActiveThreadCount(s)
+}
+
+func (agent *agent) sendActiveThreadCount(s *activeThreadCountStream) {
+	Log("cmd").Infof("active thread count stream goroutine start: %d, %d", s.reqId, agent.cmdGrpc.atcStreams.count())
+
+	// Deferred so that every exit path - send error, stop request and agent
+	// shutdown alike - frees the slot this stream holds.
+	defer func() {
+		s.close()
+		agent.cmdGrpc.atcStreams.remove(s)
+		Log("cmd").Infof("active thread count stream goroutine finish: %d, %d", s.reqId, agent.cmdGrpc.atcStreams.count())
+	}()
+
+	shutdown := agent.stopSignal().Done()
+	for agent.enable.Load() && !s.stopped() {
 		err := s.sendActiveThreadCount()
 		if err != nil {
 			if err != io.EOF {
 				Log("cmd").Errorf("send active thread count - %d, %v", s.reqId, err)
 			}
-			break
+			return
 		}
-		time.Sleep(1 * time.Second)
-	}
-	s.close()
 
-	atomic.AddInt32(&gAtcStreamCount, -1)
-	Log("cmd").Infof("active thread count stream goroutine finish: %d, %d", s.reqId, gAtcStreamCount)
+		// Returning from inside the select rather than falling through to the
+		// loop condition: shutdown is signalled before agent.enable is cleared,
+		// so a stopped stream that only re-tested enable would spin.
+		select {
+		case <-s.stop:
+			return
+		case <-shutdown:
+			return
+		case <-time.After(activeThreadCountInterval):
+		}
+	}
 }
 
 func addRealTimeSampledActiveSpan(span *span) {
-	if gAtcStreamCount > 0 {
+	if atomic.LoadInt32(&gAtcStreamCount) > 0 {
 		span.goroutineId = curGoroutineID()
 		s := &activeSpanInfo{span.startTime, span.txId.String(), span.rpcName, true}
 		realTimeActiveSpan.Store(span.goroutineId, s)
@@ -115,7 +222,7 @@ func dropRealTimeSampledActiveSpan(span *span) {
 }
 
 func addRealTimeUnSampledActiveSpan(span *noopSpan) {
-	if gAtcStreamCount > 0 {
+	if atomic.LoadInt32(&gAtcStreamCount) > 0 {
 		span.goroutineId = curGoroutineID()
 		s := &activeSpanInfo{span.startTime, "", span.rpcName, false}
 		realTimeActiveSpan.Store(span.goroutineId, s)

--- a/command_test.go
+++ b/command_test.go
@@ -1,0 +1,109 @@
+package pinpoint
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}
+
+// drainAtcStreams shuts the agent down and asserts that every stream left the
+// registry, which is the agent shutdown arm of the three exit paths.
+func drainAtcStreams(t *testing.T, agent *agent) {
+	t.Helper()
+
+	agent.signalShutdown()
+	waitFor(t, "active thread count streams to drain on shutdown", func() bool {
+		return agent.cmdGrpc.atcStreams.count() == 0
+	})
+}
+
+func Test_agent_handleActiveThreadCountRejectsBeyondLimit(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	cmd, client := newMockCmdGrpc(agent)
+	defer drainAtcStreams(t, agent)
+
+	base := runtime.NumGoroutine()
+	for i := 0; i < maxActiveThreadCountStreams; i++ {
+		agent.handleActiveThreadCount(int32(i), cmd)
+	}
+	assert.Equal(t, maxActiveThreadCountStreams, agent.cmdGrpc.atcStreams.count())
+
+	const excess = 20
+	for i := 0; i < excess; i++ {
+		agent.handleActiveThreadCount(int32(maxActiveThreadCountStreams+i), cmd)
+	}
+
+	assert.Equal(t, maxActiveThreadCountStreams, agent.cmdGrpc.atcStreams.count())
+	// Rejected requests open no stream and leave no goroutine behind.
+	assert.Equal(t, maxActiveThreadCountStreams, client.streamCount())
+	assert.LessOrEqual(t, runtime.NumGoroutine()-base, maxActiveThreadCountStreams+2)
+
+	fails := cmd.stream.(*mockCmdStream).failMessages()
+	assert.Len(t, fails, excess)
+	for i, f := range fails {
+		assert.Equal(t, int32(maxActiveThreadCountStreams+i), f.GetResponseId())
+		assert.Equal(t, "too many active thread count streams", f.GetMessage().GetValue())
+	}
+}
+
+func Test_agent_handleActiveThreadCountReplacesSameRequestId(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	cmd, client := newMockCmdGrpc(agent)
+	defer drainAtcStreams(t, agent)
+
+	agent.handleActiveThreadCount(7, cmd)
+	waitFor(t, "first stream to sample", func() bool { return client.stream(0).sendCount() > 0 })
+
+	agent.handleActiveThreadCount(7, cmd)
+
+	waitFor(t, "superseded stream to close", func() bool { return client.stream(0).isClosed() })
+	waitFor(t, "superseded stream to leave the registry", func() bool {
+		return agent.cmdGrpc.atcStreams.count() == 1
+	})
+	assert.Equal(t, 2, client.streamCount())
+	assert.False(t, client.stream(1).isClosed())
+	// A re-issue is served, not rejected.
+	assert.Empty(t, cmd.stream.(*mockCmdStream).failMessages())
+}
+
+func Test_agent_handleActiveThreadCountReleasesSlotOnSendError(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	cmd, client := newMockCmdGrpc(agent)
+	defer drainAtcStreams(t, agent)
+
+	client.sendErr = errors.New("send failed")
+	agent.handleActiveThreadCount(1, cmd)
+
+	waitFor(t, "failed stream to leave the registry", func() bool {
+		return agent.cmdGrpc.atcStreams.count() == 0
+	})
+	assert.True(t, client.stream(0).isClosed())
+}
+
+func Test_agent_handleActiveThreadCountReleasesSlotWhenStreamCannotOpen(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	cmd, client := newMockCmdGrpc(agent)
+	defer drainAtcStreams(t, agent)
+
+	client.openErr = errors.New("open failed")
+	agent.handleActiveThreadCount(1, cmd)
+
+	assert.Equal(t, 0, agent.cmdGrpc.atcStreams.count())
+	assert.Equal(t, 0, client.streamCount())
+}

--- a/grpc.go
+++ b/grpc.go
@@ -1413,10 +1413,11 @@ func makePUriHistogram(h *urlStatHistogram) *pb.PUriHistogram {
 }
 
 type cmdGrpc struct {
-	cmdConn   *grpc.ClientConn
-	cmdClient pb.ProfilerCommandServiceClient
-	stream    *cmdStream
-	agent     *agent
+	cmdConn    *grpc.ClientConn
+	cmdClient  pb.ProfilerCommandServiceClient
+	stream     *cmdStream
+	agent      *agent
+	atcStreams atcStreams
 }
 
 type cmdStream struct {
@@ -1504,6 +1505,35 @@ func (s *cmdStream) sendCommandMessage() error {
 	return err
 }
 
+// sendFailMessage rejects a command on the command stream itself, which is the
+// only channel the protocol offers for a request the agent will not serve:
+// PCmdMessage.failMessage. Matches the C++ agent's write_fail_message(), which
+// sets the request id and a reason and leaves status at its default.
+func (s *cmdStream) sendFailMessage(reqId int32, msg string) error {
+	if s.stream == nil {
+		return status.Errorf(codes.Unavailable, "command stream is nil")
+	}
+
+	gCmd := &pb.PCmdMessage{
+		Message: &pb.PCmdMessage_FailMessage{
+			FailMessage: &pb.PCmdResponse{
+				ResponseId: reqId,
+				Message:    &wrappers.StringValue{Value: msg},
+			},
+		},
+	}
+
+	if IsLogLevelEnabled(logrus.DebugLevel) {
+		Log("grpc").Debugf("PCmdMessage: %s", gCmd.String())
+	}
+
+	err := sendStreamWithTimeout(func() error { return s.stream.Send(gCmd) }, s.cancel, sendStreamTimeOut, "cmd stream.Send()")
+	if err != nil {
+		s.cancel()
+	}
+	return err
+}
+
 func (s *cmdStream) recvCommandRequest() (*pb.PCmdRequest, error) {
 	var gCmdReq *pb.PCmdRequest
 
@@ -1527,18 +1557,46 @@ type activeThreadCountStream struct {
 	reqId    int32
 	actCount int32
 	cancel   context.CancelFunc
+
+	// stop is the only cross-goroutine signal to this stream, closed by
+	// requestStop. cancel stays owned by the goroutine running the stream, so
+	// a stop never races with the stream being opened.
+	stop     chan struct{}
+	stopOnce sync.Once
 }
 
-func (cmdGrpc *cmdGrpc) newActiveThreadCountStream(reqId int32) *activeThreadCountStream {
+func newActiveThreadCountStream(reqId int32) *activeThreadCountStream {
+	return &activeThreadCountStream{reqId: reqId, stop: make(chan struct{})}
+}
+
+// openActiveThreadCountStream opens the gRPC stream for an already registered
+// s and reports whether it succeeded.
+func (cmdGrpc *cmdGrpc) openActiveThreadCountStream(s *activeThreadCountStream) bool {
 	ctx, cancel := context.WithCancel(grpcMetadataContext(cmdGrpc.agent, -1))
 	stream, err := cmdGrpc.cmdClient.CommandStreamActiveThreadCount(ctx)
 	if err != nil {
 		cancel()
 		Log("grpc").Errorf("make active thread count stream - %v", err)
-		return &activeThreadCountStream{nil, -1, 0, nil}
+		return false
 	}
 
-	return &activeThreadCountStream{stream, reqId, 0, cancel}
+	s.stream, s.cancel = stream, cancel
+	return true
+}
+
+// requestStop asks the stream to finish. Safe from any goroutine, and safe to
+// call more than once - a stream can be superseded while already stopping.
+func (s *activeThreadCountStream) requestStop() {
+	s.stopOnce.Do(func() { close(s.stop) })
+}
+
+func (s *activeThreadCountStream) stopped() bool {
+	select {
+	case <-s.stop:
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *activeThreadCountStream) close() {

--- a/mock_grpc.go
+++ b/mock_grpc.go
@@ -3,6 +3,7 @@ package pinpoint
 import (
 	"context"
 	"errors"
+	"io"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	empty "github.com/golang/protobuf/ptypes/empty"
 	pb "github.com/pinpoint-apm/pinpoint-go-agent/protobuf"
 	"github.com/pinpoint-apm/pinpoint-go-agent/protobuf/mock"
+	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -228,4 +230,110 @@ func newRetryMockStatGrpc(agent *agent, t *testing.T) *statGrpc {
 	//stream.EXPECT().Send(gomock.Any()).Return(errors.New("stat send fail"))
 
 	return &statGrpc{nil, &statClient, nil, agent}
+}
+
+// mockAtcStream stands in for the collector side of an active thread count
+// stream: it counts samples and records that it was closed.
+type mockAtcStream struct {
+	grpc.ClientStream // never called; the agent only uses Send/CloseAndRecv
+	mu                sync.Mutex
+	sends             int
+	closed            bool
+	sendErr           error
+}
+
+func (s *mockAtcStream) Send(*pb.PCmdActiveThreadCountRes) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sends++
+	return s.sendErr
+}
+
+func (s *mockAtcStream) CloseAndRecv() (*empty.Empty, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return &empty.Empty{}, nil
+}
+
+func (s *mockAtcStream) sendCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.sends
+}
+
+func (s *mockAtcStream) isClosed() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closed
+}
+
+// mockCmdStream records what the agent writes back on the command stream.
+type mockCmdStream struct {
+	grpc.ClientStream // never called; the agent only uses Send/Recv
+	mu                sync.Mutex
+	sent              []*pb.PCmdMessage
+}
+
+func (s *mockCmdStream) Send(m *pb.PCmdMessage) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = append(s.sent, m)
+	return nil
+}
+
+func (s *mockCmdStream) Recv() (*pb.PCmdRequest, error) {
+	return nil, io.EOF
+}
+
+func (s *mockCmdStream) failMessages() []*pb.PCmdResponse {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	fails := make([]*pb.PCmdResponse, 0, len(s.sent))
+	for _, m := range s.sent {
+		if f := m.GetFailMessage(); f != nil {
+			fails = append(fails, f)
+		}
+	}
+	return fails
+}
+
+// mockCmdGrpcClient hands out mockAtcStreams and keeps them in issue order.
+type mockCmdGrpcClient struct {
+	pb.ProfilerCommandServiceClient // never called; only the method below is
+	mu                              sync.Mutex
+	streams                         []*mockAtcStream
+	sendErr                         error
+	openErr                         error
+}
+
+func (c *mockCmdGrpcClient) CommandStreamActiveThreadCount(ctx context.Context, opts ...grpc.CallOption) (pb.ProfilerCommandService_CommandStreamActiveThreadCountClient, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.openErr != nil {
+		return nil, c.openErr
+	}
+	s := &mockAtcStream{sendErr: c.sendErr}
+	c.streams = append(c.streams, s)
+	return s, nil
+}
+
+func (c *mockCmdGrpcClient) stream(i int) *mockAtcStream {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.streams[i]
+}
+
+func (c *mockCmdGrpcClient) streamCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.streams)
+}
+
+// newMockCmdGrpc wires a test agent to a mock command service, returning the
+// command stream the agent answers on and the client that hands out streams.
+func newMockCmdGrpc(agent *agent) (*cmdStream, *mockCmdGrpcClient) {
+	client := &mockCmdGrpcClient{}
+	agent.cmdGrpc = &cmdGrpc{cmdClient: client, agent: agent}
+	return &cmdStream{stream: &mockCmdStream{}, cancel: func() {}}, client
 }


### PR DESCRIPTION
## Summary

Resolves #164.

Every `PCmdRequest_CommandActiveThreadCount` opened a fresh gRPC stream and
started a fresh goroutine, with no upper bound and no notion of a request id
already being served. The web UI re-requests the real-time active-thread view
whenever a user opens it, and the collector re-issues a command for a request id
it still owns after a command-stream reconnect, so goroutines and streams grew
for the lifetime of the process.

This caps the running streams at 10 — matching the C++ agent's
`max_active_thread_count_streams` — rejects the excess on the wire, and makes a
re-issued request id reclaim its predecessor.

## Changes

- **Registry with a cap.** `cmdGrpc` gains a registry of running streams, capped
  at 10. Requests over the cap are answered with `PCmdMessage.failMessage` on the
  command stream, the only rejection channel the protocol offers; the response
  carries the request id and a reason and leaves `status` at its default,
  mirroring the C++ `write_fail_message()`.
- **Register before opening.** The cap and the stop of a same-id predecessor are
  decided under one lock, so a rejected request never opens a gRPC stream at all.
  Hence the constructor split into `newActiveThreadCountStream` (allocate) and
  `openActiveThreadCountStream` (open).
- **Keyed by identity, not request id.** A predecessor told to stop stays
  registered — and counted — until its goroutine returns. Keying by request id
  would drop it the moment its successor arrived, letting a re-request loop pile
  up draining goroutines behind the cap, and would leave the predecessor's
  cleanup deleting its successor's entry.
- **Cancellable wait, deferred removal.** The per-sample `time.Sleep` becomes a
  select over the stop channel, the agent stop signal and the interval, so a stop
  takes effect at once. Removal moves into a `defer`, covering all three exits:
  send error, stop request and agent shutdown.
- **`gAtcStreamCount`** is now published from the registry under its lock and
  read atomically on the span hot path, where it was previously read without
  synchronization while being written with `atomic.AddInt32`.

The cap is a constant rather than a config key: the C++ agent keeps the same
value as a tuning constant, and ten concurrent real-time viewers of one agent is
already well past what the UI produces.

`ACTIVE_THREAD_DUMP` and `ACTIVE_THREAD_LIGHT_DUMP` need no change — both are
synchronous unary calls made on the command goroutine and bounded by
`commandStreamTimeOut`, so they spawn nothing and hold no stream.

## Testing

- `go test -race ./...` (root module) — passes.
- `go test -short ./...` in `test/it` — passes, including
  `TestRestartsActiveThreadCountStreamForDuplicateRequest`, which already pinned
  the re-issue behavior against the mock collector.
- `go test -race -short -run 'Command|ActiveThread' .` in `test/it` — all pass.
- New unit tests in `command_test.go`: the reject path (goroutine count via
  `runtime.NumGoroutine()` and opened streams both stop at the cap, and every
  rejected id gets a fail message), the re-issue path, and slot release on send
  error and on a stream that cannot be opened. Each test's teardown asserts the
  registry drains to zero on shutdown.
- Mutation-checked that the new tests are not vacuous: with the cap and the
  same-id stop disabled, the reject test reports 30 goroutines and 0 fail
  messages, and the re-issue test times out.

Unrelated pre-existing issue noticed while verifying: `test/it` under `-race`
fails `TestRecoversTracingAcrossRepeatedCreateShutdownCycles` with a race in
`stats.go` (`initStats` writes the global `activeSpanRegistry` while
`dropSampledActiveSpan` reads it). It reproduces on a clean `main` checkout, so
it is not from this branch.
