### PR TITLE
[#167] Bound and pipeline metadata sends so a slow collector cannot wedge the worker

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -542,46 +542,62 @@ func (agent *agent) sendMetaWorker() {
 	Log("agent").Infof("start meta goroutine")
 	defer agent.workerWg.Done()
 
+	// Metadata sends are pipelined: registration has no ordering requirement
+	// (the collector accepts duplicates and metadata arriving after its
+	// spans), while serial sends cap throughput at one item per round trip,
+	// which falls behind when high error rates produce exception metadata
+	// per span.
+	permit := make(chan struct{}, metaMaxConcurrentRequests)
+	var inFlight sync.WaitGroup
+	// Deferred so both exits -- the stop signal and a disabled agent -- wait
+	// for the sends already accepted, giving them the same best-effort flush.
+	defer func() {
+		inFlight.Wait()
+		Log("agent").Infof("end meta goroutine")
+	}()
+
 	stop := agent.stopSignal().Done()
 
 	for agent.enable.Load() {
 		var md interface{}
 		select {
 		case <-stop:
-			Log("agent").Infof("end meta goroutine")
 			return
 		case md = <-agent.metaChan:
 		}
 
-		var success bool
-		switch md.(type) {
-		case apiMeta:
-			api := md.(apiMeta)
-			success = agent.agentGrpc.sendApiMetadataWithRetry(api.id, api.descriptor, -1, api.apiType)
-			break
-		case stringMeta:
-			str := md.(stringMeta)
-			success = agent.agentGrpc.sendStringMetadataWithRetry(str.id, str.funcName)
-			break
-		case sqlMeta:
-			sql := md.(sqlMeta)
-			success = agent.agentGrpc.sendSqlMetadataWithRetry(sql.id, sql.sql)
-			break
-		case sqlUidMeta:
-			sql := md.(sqlUidMeta)
-			success = agent.agentGrpc.sendSqlUidMetadataWithRetry(sql.uid, sql.sql)
-			break
-		case exceptionMeta:
-			em := md.(exceptionMeta)
-			success = agent.agentGrpc.sendExceptionMetadataWithRetry(&em)
-		}
+		permit <- struct{}{}
+		inFlight.Add(1)
+		go func(md interface{}) {
+			defer inFlight.Done()
+			defer func() { <-permit }()
 
-		if !success {
-			agent.deleteMetaCache(md)
-		}
+			if !agent.sendMetadata(md) {
+				agent.deleteMetaCache(md)
+			}
+		}(md)
 	}
+}
 
-	Log("agent").Infof("end meta goroutine")
+func (agent *agent) sendMetadata(md interface{}) bool {
+	switch md.(type) {
+	case apiMeta:
+		api := md.(apiMeta)
+		return agent.agentGrpc.sendApiMetadataWithRetry(api.id, api.descriptor, -1, api.apiType)
+	case stringMeta:
+		str := md.(stringMeta)
+		return agent.agentGrpc.sendStringMetadataWithRetry(str.id, str.funcName)
+	case sqlMeta:
+		sql := md.(sqlMeta)
+		return agent.agentGrpc.sendSqlMetadataWithRetry(sql.id, sql.sql)
+	case sqlUidMeta:
+		sql := md.(sqlUidMeta)
+		return agent.agentGrpc.sendSqlUidMetadataWithRetry(sql.uid, sql.sql)
+	case exceptionMeta:
+		em := md.(exceptionMeta)
+		return agent.agentGrpc.sendExceptionMetadataWithRetry(&em)
+	}
+	return false
 }
 
 func (agent *agent) deleteMetaCache(md interface{}) {

--- a/grpc.go
+++ b/grpc.go
@@ -413,6 +413,33 @@ func isRetryableError(e error) bool {
 	return code == codes.Unavailable || code == codes.DeadlineExceeded
 }
 
+// metaRetryMaxAttempts bounds sends of one metadata item, matching the C++
+// agent's meta_retry_max_attempts. All metadata is sent serially from the
+// single sendMetaWorker goroutine; without a bound, one item facing a slow
+// collector occupies the worker forever while metaChan overflows and new
+// metadata is dropped.
+const metaRetryMaxAttempts = 3
+
+// retryMeta reports failure once the attempt budget is exhausted so that
+// sendMetaWorker releases the item's cache entry and the metadata is
+// re-registered on its next use.
+func (agentGrpc *agentGrpc) retryMeta(send func() error) bool {
+	for attempt := 1; agentGrpc.agent.Enable(); attempt++ {
+		err := send()
+		if err == nil {
+			return true
+		}
+		if !isRetryableError(err) || attempt >= metaRetryMaxAttempts {
+			break
+		}
+
+		if !agentGrpc.agent.config.offGrpc {
+			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
+		}
+	}
+	return false
+}
+
 func (agentGrpc *agentGrpc) sendApiMetadata(in *pb.PApiMetaData) error {
 	ctx, cancel := context.WithTimeout(grpcMetadataContext(agentGrpc.agent, -1), agentGrpcTimeOut)
 	defer cancel()
@@ -436,18 +463,9 @@ func (agentGrpc *agentGrpc) sendApiMetadataWithRetry(apiId int32, api string, li
 		Log("grpc").Debugf("api metadata: %s", apiMeta.String())
 	}
 
-	for agentGrpc.agent.Enable() {
-		if err := agentGrpc.sendApiMetadata(&apiMeta); err == nil {
-			return true
-		} else if !isRetryableError(err) {
-			break
-		}
-
-		if !agentGrpc.agent.config.offGrpc {
-			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
-		}
-	}
-	return false
+	return agentGrpc.retryMeta(func() error {
+		return agentGrpc.sendApiMetadata(&apiMeta)
+	})
 }
 
 func (agentGrpc *agentGrpc) sendStringMetadata(in *pb.PStringMetaData) error {
@@ -471,18 +489,9 @@ func (agentGrpc *agentGrpc) sendStringMetadataWithRetry(strId int32, str string)
 		Log("grpc").Debugf("string metadata: %s", strMeta.String())
 	}
 
-	for agentGrpc.agent.Enable() {
-		if err := agentGrpc.sendStringMetadata(&strMeta); err == nil {
-			return true
-		} else if !isRetryableError(err) {
-			break
-		}
-
-		if !agentGrpc.agent.config.offGrpc {
-			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
-		}
-	}
-	return false
+	return agentGrpc.retryMeta(func() error {
+		return agentGrpc.sendStringMetadata(&strMeta)
+	})
 }
 
 func (agentGrpc *agentGrpc) sendSqlMetadata(in *pb.PSqlMetaData) error {
@@ -507,18 +516,9 @@ func (agentGrpc *agentGrpc) sendSqlMetadataWithRetry(sqlId int32, sql string) bo
 		Log("grpc").Debugf("sql metadata: %s", sqlMeta.String())
 	}
 
-	for agentGrpc.agent.Enable() {
-		if err := agentGrpc.sendSqlMetadata(&sqlMeta); err == nil {
-			return true
-		} else if !isRetryableError(err) {
-			break
-		}
-
-		if !agentGrpc.agent.config.offGrpc {
-			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
-		}
-	}
-	return false
+	return agentGrpc.retryMeta(func() error {
+		return agentGrpc.sendSqlMetadata(&sqlMeta)
+	})
 }
 
 func (agentGrpc *agentGrpc) sendSqlUidMetadata(in *pb.PSqlUidMetaData) error {
@@ -543,18 +543,9 @@ func (agentGrpc *agentGrpc) sendSqlUidMetadataWithRetry(sqlUid []byte, sql strin
 		Log("grpc").Debugf("sql uid metadata: %s", sqlUidMeta.String())
 	}
 
-	for agentGrpc.agent.Enable() {
-		if err := agentGrpc.sendSqlUidMetadata(&sqlUidMeta); err == nil {
-			return true
-		} else if !isRetryableError(err) {
-			break
-		}
-
-		if !agentGrpc.agent.config.offGrpc {
-			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
-		}
-	}
-	return false
+	return agentGrpc.retryMeta(func() error {
+		return agentGrpc.sendSqlUidMetadata(&sqlUidMeta)
+	})
 }
 
 func (agentGrpc *agentGrpc) sendExceptionMetadata(in *pb.PExceptionMetaData) error {
@@ -583,18 +574,9 @@ func (agentGrpc *agentGrpc) sendExceptionMetadataWithRetry(exception *exceptionM
 		Log("grpc").Debugf("exception metadata: %s", exceptMeta.String())
 	}
 
-	for agentGrpc.agent.Enable() {
-		if err := agentGrpc.sendExceptionMetadata(exceptMeta); err == nil {
-			return true
-		} else if !isRetryableError(err) {
-			break
-		}
-
-		if !agentGrpc.agent.config.offGrpc {
-			backOffUntilReady(agentGrpc.agent, agentGrpc.agentConn, "agent")
-		}
-	}
-	return false
+	return agentGrpc.retryMeta(func() error {
+		return agentGrpc.sendExceptionMetadata(exceptMeta)
+	})
 }
 
 func makePExceptionMetaData(e *exceptionMeta) *pb.PExceptionMetaData {

--- a/grpc.go
+++ b/grpc.go
@@ -420,6 +420,11 @@ func isRetryableError(e error) bool {
 // metadata is dropped.
 const metaRetryMaxAttempts = 3
 
+// metaMaxConcurrentRequests bounds how many metadata sends sendMetaWorker
+// keeps in flight at once, matching the C++ agent's
+// meta_max_concurrent_requests.
+const metaMaxConcurrentRequests = 4
+
 // retryMeta reports failure once the attempt budget is exhausted so that
 // sendMetaWorker releases the item's cache entry and the metadata is
 // re-registered on its next use.

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -628,6 +628,108 @@ func Test_sendStreamWithTimeout_unresponsiveStreamLeaksNothing(t *testing.T) {
 	assert.LessOrEqual(t, runtime.NumGoroutine(), before+2)
 }
 
+// failingMetaClient fails every metadata request with a fixed error, counting
+// the attempts.
+type failingMetaClient struct {
+	calls int32
+	err   error
+}
+
+func (c *failingMetaClient) fail() error {
+	atomic.AddInt32(&c.calls, 1)
+	return c.err
+}
+
+func (c *failingMetaClient) callCount() int32 {
+	return atomic.LoadInt32(&c.calls)
+}
+
+func (c *failingMetaClient) RequestApiMetaData(context.Context, *pb.PApiMetaData) (*pb.PResult, error) {
+	return nil, c.fail()
+}
+
+func (c *failingMetaClient) RequestSqlMetaData(context.Context, *pb.PSqlMetaData) (*pb.PResult, error) {
+	return nil, c.fail()
+}
+
+func (c *failingMetaClient) RequestSqlUidMetaData(context.Context, *pb.PSqlUidMetaData) (*pb.PResult, error) {
+	return nil, c.fail()
+}
+
+func (c *failingMetaClient) RequestStringMetaData(context.Context, *pb.PStringMetaData) (*pb.PResult, error) {
+	return nil, c.fail()
+}
+
+func (c *failingMetaClient) RequestExceptionMetaData(context.Context, *pb.PExceptionMetaData) (*pb.PResult, error) {
+	return nil, c.fail()
+}
+
+func newFailingMetaAgentGrpc(agent *agent, err error) (*agentGrpc, *failingMetaClient) {
+	failing := &failingMetaClient{err: err}
+	return &agentGrpc{metaClient: failing, agent: agent}, failing
+}
+
+func Test_retryMeta_stopsAtRetryBound(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	agentGrpc, failing := newFailingMetaAgentGrpc(agent, status.Errorf(codes.Unavailable, "collector down"))
+
+	ok := agentGrpc.sendApiMetadataWithRetry(1, "test.api", -1, apiTypeInvocation)
+
+	assert.False(t, ok, "retryable errors must stop at the bound")
+	assert.Equal(t, int32(metaRetryMaxAttempts), failing.callCount())
+}
+
+func Test_retryMeta_noRetryOnNonRetryableError(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	agentGrpc, failing := newFailingMetaAgentGrpc(agent, status.Errorf(codes.Internal, "bad request"))
+
+	ok := agentGrpc.sendStringMetadataWithRetry(1, "test.error")
+
+	assert.False(t, ok)
+	assert.Equal(t, int32(1), failing.callCount(), "non-retryable errors must not retry")
+}
+
+// A collector that keeps failing must not wedge the metadata worker: each item
+// gives up at the retry bound, the worker moves on to the next item, and the
+// failed items' cache entries are released so their next use re-registers them.
+func Test_sendMetaWorker_movesOnAndReleasesCache(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	agentGrpc, failing := newFailingMetaAgentGrpc(agent, status.Errorf(codes.Unavailable, "collector down"))
+	agent.agentGrpc = agentGrpc
+
+	apiKey := apiCacheKey{"test.api", apiTypeInvocation}
+	apiCached := func() bool { _, ok := agent.apiCache.peek(apiKey); return ok }
+	errCached := func() bool { _, ok := agent.errorCache.peek("test.error"); return ok }
+	assert.NotZero(t, agent.cacheSpanApi(apiKey.descriptor, apiKey.apiType))
+	assert.NotZero(t, agent.cacheError("test.error"))
+	assert.True(t, apiCached())
+	assert.True(t, errCached())
+
+	agent.workerWg.Add(1)
+	go agent.sendMetaWorker()
+
+	// both queued items exhaust their retry budget: the worker was not wedged
+	// by the first one
+	assert.Eventually(t, func() bool {
+		return failing.callCount() == int32(2*metaRetryMaxAttempts)
+	}, 5*time.Second, 5*time.Millisecond, "worker must drain both items, got %d calls", failing.callCount())
+
+	agent.signalShutdown()
+	agent.workerWg.Wait()
+
+	// the failed items released their cache entries...
+	assert.False(t, apiCached())
+	assert.False(t, errCached())
+
+	// ...so the next use re-registers and re-enqueues the metadata
+	assert.NotZero(t, agent.cacheSpanApi(apiKey.descriptor, apiKey.apiType))
+	assert.True(t, apiCached())
+	assert.Equal(t, 1, len(agent.metaChan))
+}
+
 // countingAgentClient counts RequestAgentInfo calls and fails them on demand.
 type countingAgentClient struct {
 	calls atomic.Int32

--- a/grpc_test.go
+++ b/grpc_test.go
@@ -730,6 +730,99 @@ func Test_sendMetaWorker_movesOnAndReleasesCache(t *testing.T) {
 	assert.Equal(t, 1, len(agent.metaChan))
 }
 
+// blockingMetaClient parks every metadata request until release is closed,
+// tracking how many requests are in flight at once.
+type blockingMetaClient struct {
+	mu      sync.Mutex
+	current int
+	max     int
+	total   int
+	release chan struct{}
+}
+
+func (c *blockingMetaClient) block() error {
+	c.mu.Lock()
+	c.current++
+	c.total++
+	if c.current > c.max {
+		c.max = c.current
+	}
+	c.mu.Unlock()
+
+	<-c.release
+
+	c.mu.Lock()
+	c.current--
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *blockingMetaClient) inFlight() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.current
+}
+
+func (c *blockingMetaClient) stats() (max, total int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.max, c.total
+}
+
+func (c *blockingMetaClient) RequestApiMetaData(context.Context, *pb.PApiMetaData) (*pb.PResult, error) {
+	return nil, c.block()
+}
+
+func (c *blockingMetaClient) RequestSqlMetaData(context.Context, *pb.PSqlMetaData) (*pb.PResult, error) {
+	return nil, c.block()
+}
+
+func (c *blockingMetaClient) RequestSqlUidMetaData(context.Context, *pb.PSqlUidMetaData) (*pb.PResult, error) {
+	return nil, c.block()
+}
+
+func (c *blockingMetaClient) RequestStringMetaData(context.Context, *pb.PStringMetaData) (*pb.PResult, error) {
+	return nil, c.block()
+}
+
+func (c *blockingMetaClient) RequestExceptionMetaData(context.Context, *pb.PExceptionMetaData) (*pb.PResult, error) {
+	return nil, c.block()
+}
+
+// While earlier sends are still waiting on the collector, the worker must keep
+// pulling items and pipeline up to metaMaxConcurrentRequests sends -- and no
+// more.
+func Test_sendMetaWorker_pipelinesUpToConcurrencyLimit(t *testing.T) {
+	cfg, _ := NewConfig(WithAppName("TestApp"))
+	agent := newTestAgent(cfg)
+	blocking := &blockingMetaClient{release: make(chan struct{})}
+	agent.agentGrpc = &agentGrpc{metaClient: blocking, agent: agent}
+
+	const items = 2 * metaMaxConcurrentRequests
+	for i := 0; i < items; i++ {
+		agent.metaChan <- apiMeta{id: int32(i), descriptor: "test.api", apiType: apiTypeInvocation}
+	}
+
+	agent.workerWg.Add(1)
+	go agent.sendMetaWorker()
+
+	assert.Eventually(t, func() bool {
+		return blocking.inFlight() == metaMaxConcurrentRequests
+	}, 5*time.Second, time.Millisecond, "sends must pipeline while the collector is slow")
+
+	close(blocking.release)
+	assert.Eventually(t, func() bool {
+		_, total := blocking.stats()
+		return total == items
+	}, 5*time.Second, time.Millisecond, "every queued item must be sent")
+
+	agent.signalShutdown()
+	agent.workerWg.Wait()
+
+	max, _ := blocking.stats()
+	assert.Equal(t, metaMaxConcurrentRequests, max, "in-flight sends must not exceed the limit")
+}
+
 // countingAgentClient counts RequestAgentInfo calls and fails them on demand.
 type countingAgentClient struct {
 	calls atomic.Int32


### PR DESCRIPTION
Fixes #167

Metadata sends ran unbounded retry loops on the single `sendMetaWorker` goroutine, so a slow or partially down collector let one item occupy the worker forever while `metaChan` filled up and new metadata was silently dropped — turning a collector outage into permanent observability loss.

### Bound the retry loop (44369fa)

The five `send*MetadataWithRetry` functions each ran their own copy of the same `for agent.Enable()` loop, retrying `Unavailable` / `DeadlineExceeded` forever. They now share a `retryMeta` helper capped at `metaRetryMaxAttempts = 3`, matching the C++ agent's `meta_retry_max_attempts`; the five duplicated loops are gone.

On exhaustion the send reports failure, which takes the existing `deleteMetaCache` path: the item's cache entry is released, so the metadata is re-registered and re-sent on its next use once the collector recovers. Non-retryable errors still fail on the first attempt, as before.

### Pipeline the sends (bc9b246)

Serial sends cap metadata throughput at one item per round trip, which falls behind when high error rates produce exception metadata per span. `sendMetaWorker` now dispatches each item to a send goroutine gated by a permit channel of `metaMaxConcurrentRequests = 4`, matching the C++ agent's `meta_max_concurrent_requests`. Metadata registration has no ordering requirement — the collector accepts duplicate ids and metadata arriving after its spans — so nothing constrains the pipelining. The worker waits for in-flight sends before exiting, so shutdown still flushes accepted items.

### Notes

Both limits are constants rather than configuration keys: they match the C++ defaults and there is no demonstrated need to tune them per deployment yet.

### Tests

`grpc_test.go` covers, against a collector that keeps returning `Unavailable`:

- retries stop at the bound, and a non-retryable error still does not retry
- the worker moves on to the next item instead of wedging on the first, and `metaChan` keeps draining
- the failed items' cache entries are released, and the next use re-registers and re-enqueues the metadata
- sends pipeline up to 4 in flight and never exceed it, with every queued item sent

`go test -race ./...` passes.
