### PR TITLE
[#129] Stop closing the agent channels producers still send on

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -339,10 +339,15 @@ func (agent *agent) Shutdown() {
 
 	globalAgent = NoopAgent()
 
+	// spanQueue.close() signals; it does not close the channel producers use.
+	// The three chans below get the same treatment - deliberately never closed.
+	// Their producers (request-path goroutines for url stat and meta, ticker
+	// workers for stat) only check enable before sending, which is check-then-
+	// act against a close and panics with "send on closed channel" when the
+	// send lands after it. signalShutdown() above already cancelled stopCtx,
+	// which is what stops the consumers; whatever is still queued is dropped
+	// with the channel itself.
 	agent.spanQueue.close()
-	close(agent.metaChan)
-	close(agent.statChan)
-	close(agent.urlStatChan)
 
 	//To terminate the listening state of the command stream,
 	//close the command grpc channel first
@@ -537,9 +542,15 @@ func (agent *agent) sendMetaWorker() {
 	Log("agent").Infof("start meta goroutine")
 	defer agent.workerWg.Done()
 
-	for md := range agent.metaChan {
-		if !agent.enable.Load() {
-			break
+	stop := agent.stopSignal().Done()
+
+	for agent.enable.Load() {
+		var md interface{}
+		select {
+		case <-stop:
+			Log("agent").Infof("end meta goroutine")
+			return
+		case md = <-agent.metaChan:
 		}
 
 		var success bool
@@ -793,11 +804,16 @@ func (agent *agent) collectUrlStatWorker() {
 
 	agent.initUrlStat()
 
-	for uri := range agent.urlStatChan {
-		if !agent.enable.Load() {
-			break
+	stop := agent.stopSignal().Done()
+
+	for agent.enable.Load() {
+		select {
+		case <-stop:
+			Log("agent").Infof("end collect uri stat goroutine")
+			return
+		case uri := <-agent.urlStatChan:
+			agent.addUrlStatSnapshot(uri)
 		}
-		agent.addUrlStatSnapshot(uri)
 	}
 
 	Log("agent").Infof("end collect uri stat goroutine")
@@ -845,9 +861,17 @@ func (agent *agent) sendStatsWorker() {
 	defer agent.workerWg.Done()
 
 	stream := agent.statGrpc.newStatStreamWithRetry()
-	for stats := range agent.statChan {
-		if !agent.enable.Load() {
-			break
+	defer func() { stream.close() }()
+
+	stop := agent.stopSignal().Done()
+
+	for agent.enable.Load() {
+		var stats *pb.PStatMessage
+		select {
+		case <-stop:
+			Log("agent").Infof("end send stats goroutine")
+			return
+		case stats = <-agent.statChan:
 		}
 
 		err := stream.sendStats(stats)
@@ -860,7 +884,6 @@ func (agent *agent) sendStatsWorker() {
 			stream = agent.statGrpc.newStatStreamWithRetry()
 		}
 	}
-	stream.close()
 
 	Log("agent").Infof("end send stats goroutine")
 }

--- a/agent_test.go
+++ b/agent_test.go
@@ -414,3 +414,28 @@ func Test_agent_enqueueUrlStatRateLimitsOverflowWarning(t *testing.T) {
 	assert.Contains(t, buf.String(), fmt.Sprintf("%d dropped in total (max queue size %d)",
 		agent.urlStatDrops.Load(), queueSize))
 }
+
+// Shutdown must not close the channels its producers send on. The producers
+// (request-path goroutines for meta and url stat, ticker workers for stat)
+// only check enable before sending, so a close races them into a "send on
+// closed channel" panic - a raw send models a producer that passed that check
+// just before Shutdown flipped it. Shutdown must still stop the consumers,
+// which used to ride on the close, so it has to return well inside its own
+// worker deadline rather than timing out on workers stuck in a receive.
+func Test_agent_ShutdownDoesNotCloseProducerChannels(t *testing.T) {
+	agent := newTestAgent(defaultConfig())
+	agent.statChan = make(chan *pb.PStatMessage, 1)
+	agent.urlStatChan = make(chan *urlStat, 1)
+
+	agent.workerWg.Add(2)
+	go agent.sendMetaWorker()
+	go agent.collectUrlStatWorker()
+
+	start := time.Now()
+	agent.Shutdown()
+	assert.Less(t, time.Since(start), shutdownTimeout, "consumers must stop on the shutdown signal")
+
+	assert.NotPanics(t, func() { agent.metaChan <- stringMeta{} }, "metaChan")
+	assert.NotPanics(t, func() { agent.statChan <- &pb.PStatMessage{} }, "statChan")
+	assert.NotPanics(t, func() { agent.urlStatChan <- &urlStat{} }, "urlStatChan")
+}


### PR DESCRIPTION
Fixes #129

## Problem

`Shutdown` closed `metaChan`, `statChan` and `urlStatChan` while their producers were still running:

```go
agent.spanQueue.close()
close(agent.metaChan)
close(agent.statChan)
close(agent.urlStatChan)
```

Every producer (`tryEnqueueMeta`, `enqueueStat`, `enqueueUrlStat`) only checks `agent.enable` before sending. That is check-then-act against the close — when `enable` flips and the close lands between the check and `case ch <- x:`, the producer panics with `send on closed channel`.

This is not only a worker-vs-shutdown race: url stat and meta are enqueued from **request-path goroutines** at span end (`span.go`, `noop.go`), so a request finishing concurrently with `Shutdown` crashes the process.

Reproduced intermittently by `test/it` — roughly 1 in 10 runs on an M-series Mac, so it intermittently reddens CI.

## Fix

No producer-side guard can close that window, so the channels are no longer closed at all. `spanQueue` already solved this correctly — signal shutdown and let the consumer stop — and the same treatment now applies to the three remaining channels:

- The three `close()` calls are removed. `signalShutdown()` already cancels `stopCtx` before the channels are touched.
- `sendMetaWorker`, `collectUrlStatWorker` and `sendStatsWorker` `select` on the stop signal instead of ranging until a close, matching the existing `sendUrlStatWorker` idiom in the same file.
- The now-redundant `enable.Load()` check moves to the loop condition, bounding a shutdown to at most one further buffered item.
- `sendStatsWorker` gained `defer func() { stream.close() }()` since it now returns early.

Producers are unchanged — with no close, a `select` send on a buffered channel cannot panic. Whatever is still queued is dropped with the channel, which matches the previous behavior (the old loops also bailed immediately on `!enable`).

## Test

`Test_agent_ShutdownDoesNotCloseProducerChannels` covers both halves:

- Raw sends after `Shutdown` model a producer that passed its `enable` check just before it flipped — these panic on the current `main` for all three channels.
- The elapsed-time assertion catches the other half: the consumers used to rely on the close to wake up, so a consumer left blocking on a bare receive would push `Shutdown` into its 3s worker deadline.

## Verification

- Root package green under `-race`.
- `test/it` green 6/6 consecutive runs (previously ~1 in 10 failing).
- The new test fails on `main` with the reported panic:

```
Panic value:	send on closed channel
Messages:   	urlStatChan
```
