### PR TITLE
[#156] Make metadata cache hits lock-free

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -783,7 +783,7 @@ const maxCacheableSqlLength = 64 * 1024
 // normalizeSql returns the normalized SQL and extracted parameters for sql,
 // memoized by the raw SQL text so repeated statements skip re-parsing. It uses
 // the same sharded metaCache as the id caches above, so a hot statement is a
-// read-lock lookup and stays resident under aged promotion.
+// lock-free lookup and stays resident under aged promotion.
 func (agent *agent) normalizeSql(sql string) (string, string) {
 	if len(sql) > maxCacheableSqlLength {
 		return newSqlNormalizer(sql).run()

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -304,7 +304,7 @@ func BenchmarkCacheSpanApi(b *testing.B) {
 	}
 }
 
-// BenchmarkCacheSpanApiParallel measures apiCache lru lock contention across cores.
+// BenchmarkCacheSpanApiParallel measures apiCache hit scalability across cores.
 func BenchmarkCacheSpanApiParallel(b *testing.B) {
 	a := benchAgent()
 	stop := startDrain(a)

--- a/meta_cache.go
+++ b/meta_cache.go
@@ -4,6 +4,8 @@ import (
 	"container/list"
 	"hash/maphash"
 	"sync"
+	"sync/atomic"
+	"unsafe"
 )
 
 // metaCache replaces the four hashicorp/golang-lru metadata caches. That
@@ -11,13 +13,12 @@ import (
 // Peek/PeekOrAdd pattern used here never promoted entries, so eviction order
 // degenerated to insertion order (FIFO): a hot SQL was evicted before a
 // cold-but-recent one, re-issuing its id and re-sending its metadata to the
-// collector. This cache shards the key space (per-shard RWMutex) and restores
-// real LRU ordering with aged promotion, mirroring the C++ agent's
-// ShardedLruCache (src/cache.h): a hit only takes the write lock to splice
-// when the shard is full AND the entry has aged past half the shard capacity.
-// Promoting on every hit would serialize all hits behind the exclusive lock
-// (C++ measured 75 ns vs 1,333 ns per hot-set hit at 16 threads). Typed keys
-// also drop the interface{} boxing golang-lru forced on every lookup.
+// collector. This cache shards the key space and restores real LRU ordering
+// with aged promotion, mirroring the C++ agent's ShardedLruCache (src/cache.h):
+// sync.Map keeps steady-state hits lock-free, while an aged entry only takes
+// the shard lock when it needs to move to the front. Promoting on every hit
+// would serialize all hits behind the lock (C++ measured 75 ns vs 1,333 ns
+// per hot-set hit at 16 threads).
 const metaCacheShardCount = 16 // power of two; matches the C++ agent
 
 var metaCacheSeed = maphash.MakeSeed()
@@ -29,31 +30,36 @@ func hashApiCacheKey(k apiCacheKey) uint64 {
 }
 
 type metaCacheEntry[K comparable, V any] struct {
-	key   K
-	value V
-	// Shard opSeq at insert / last promotion. Written under the shard's
-	// write lock, read under its read lock.
-	lastPromoted uint64
+	key     K
+	value   V
+	element *list.Element
+	shard   *metaCacheShard
+	// Shard opSeq at insert / last promotion. Reads are lock-free.
+	lastPromoted atomic.Uint64
 }
 
-// metaCacheShard is padded to cacheLinePadSize for the same reason as
-// activeSpanShard in stats.go: the mutex and opSeq are the contended words,
-// and unpadded shards would ping-pong a shared line between goroutines
-// holding *different* shard locks. The payload is 64 bytes; the size
-// assertion in meta_cache_test.go fails if a field changes that.
-type metaCacheShard[K comparable, V any] struct {
-	mu           sync.RWMutex
-	m            map[K]*list.Element
+type metaCacheShardInternal struct {
+	mu           sync.Mutex
 	order        *list.List // front = most recently used
 	cap          int
 	ageThreshold uint64
-	opSeq        uint64 // counts inserts and promotions; entry age = opSeq - lastPromoted
-	_            [cacheLinePadSize - 64]byte
+	opSeq        atomic.Uint64 // counts inserts and promotions; entry age = opSeq - lastPromoted
+	size         atomic.Int64
+}
+
+// metaCacheShard is padded to cacheLinePadSize for the same reason as
+// activeSpanShard in stats.go: the mutex and atomics are the contended words,
+// and unpadded shards would ping-pong a shared line between goroutines using
+// *different* shards.
+type metaCacheShard struct {
+	metaCacheShardInternal
+	_ [cacheLinePadSize - unsafe.Sizeof(metaCacheShardInternal{})%cacheLinePadSize]byte
 }
 
 type metaCache[K comparable, V any] struct {
 	hash   func(K) uint64
-	shards [metaCacheShardCount]metaCacheShard[K, V]
+	m      sync.Map // K -> *metaCacheEntry[K, V]
+	shards [metaCacheShardCount]metaCacheShard
 }
 
 // newMetaCache splits capacity evenly across the shards, so a hot shard
@@ -67,7 +73,6 @@ func newMetaCache[K comparable, V any](capacity int, hash func(K) uint64) *metaC
 	}
 	for i := range c.shards {
 		s := &c.shards[i]
-		s.m = make(map[K]*list.Element, perShard+1)
 		s.order = list.New()
 		s.cap = perShard
 		s.ageThreshold = uint64(perShard / 2)
@@ -78,38 +83,43 @@ func newMetaCache[K comparable, V any](capacity int, hash func(K) uint64) *metaC
 	return c
 }
 
-func (c *metaCache[K, V]) shard(key K) *metaCacheShard[K, V] {
+func (c *metaCache[K, V]) shard(key K) *metaCacheShard {
 	return &c.shards[c.hash(key)&(metaCacheShardCount-1)]
 }
 
-// peek returns the cached value. A hit is normally a pure read-lock lookup;
-// only when the shard is full and the entry has aged past ageThreshold does
-// it take the write lock to move the entry to the front (aged promotion).
+// peek returns the cached value. A hit is normally lock-free; only when the
+// shard is full and the entry has aged past ageThreshold does it take the
+// shard lock to move the entry to the front (aged promotion).
 func (c *metaCache[K, V]) peek(key K) (V, bool) {
-	s := c.shard(key)
-	s.mu.RLock()
-	el, ok := s.m[key]
+	raw, ok := c.m.Load(key)
 	if !ok {
-		s.mu.RUnlock()
 		var zero V
 		return zero, false
 	}
-	e := el.Value.(*metaCacheEntry[K, V])
+	e := raw.(*metaCacheEntry[K, V])
+	s := e.shard
 	v := e.value
-	promote := len(s.m) >= s.cap && s.opSeq-e.lastPromoted >= s.ageThreshold
-	s.mu.RUnlock()
-
-	if promote {
-		s.mu.Lock()
-		// Re-resolve: the entry may have been evicted or removed between
-		// the two locks. The value read above is still a valid answer.
-		if el, ok := s.m[key]; ok {
-			s.order.MoveToFront(el)
-			s.opSeq++
-			el.Value.(*metaCacheEntry[K, V]).lastPromoted = s.opSeq
-		}
-		s.mu.Unlock()
+	if s.size.Load() < int64(s.cap) {
+		return v, true
 	}
+	lastPromoted := e.lastPromoted.Load()
+	opSeq := s.opSeq.Load()
+	if opSeq-lastPromoted < s.ageThreshold {
+		return v, true
+	}
+
+	s.mu.Lock()
+	// Re-resolve and re-check: another goroutine may have promoted, evicted,
+	// or removed the entry while this goroutine waited for the lock.
+	if raw, ok := c.m.Load(key); ok && raw.(*metaCacheEntry[K, V]) == e {
+		lastPromoted = e.lastPromoted.Load()
+		opSeq = s.opSeq.Load()
+		if s.size.Load() >= int64(s.cap) && opSeq-lastPromoted >= s.ageThreshold {
+			s.order.MoveToFront(e.element)
+			e.lastPromoted.Store(s.opSeq.Add(1))
+		}
+	}
+	s.mu.Unlock()
 	return v, true
 }
 
@@ -121,18 +131,21 @@ func (c *metaCache[K, V]) peek(key K) (V, bool) {
 func (c *metaCache[K, V]) peekOrAdd(key K, value V) (V, bool) {
 	s := c.shard(key)
 	s.mu.Lock()
-	if el, ok := s.m[key]; ok {
-		v := el.Value.(*metaCacheEntry[K, V]).value
+	if raw, ok := c.m.Load(key); ok {
+		v := raw.(*metaCacheEntry[K, V]).value
 		s.mu.Unlock()
 		return v, true
 	}
-	s.opSeq++
-	e := &metaCacheEntry[K, V]{key: key, value: value, lastPromoted: s.opSeq}
-	s.m[key] = s.order.PushFront(e)
-	if len(s.m) > s.cap {
-		victim := s.order.Back()
-		delete(s.m, victim.Value.(*metaCacheEntry[K, V]).key)
-		s.order.Remove(victim)
+	opSeq := s.opSeq.Add(1)
+	e := &metaCacheEntry[K, V]{key: key, value: value, shard: s}
+	e.lastPromoted.Store(opSeq)
+	e.element = s.order.PushFront(e)
+	c.m.Store(key, e)
+	if s.size.Add(1) > int64(s.cap) {
+		victim := s.order.Back().Value.(*metaCacheEntry[K, V])
+		c.m.Delete(victim.key)
+		s.order.Remove(victim.element)
+		s.size.Add(-1)
 	}
 	s.mu.Unlock()
 	var zero V
@@ -144,9 +157,11 @@ func (c *metaCache[K, V]) peekOrAdd(key K, value V) (V, bool) {
 func (c *metaCache[K, V]) remove(key K) {
 	s := c.shard(key)
 	s.mu.Lock()
-	if el, ok := s.m[key]; ok {
-		delete(s.m, key)
-		s.order.Remove(el)
+	if raw, ok := c.m.Load(key); ok {
+		e := raw.(*metaCacheEntry[K, V])
+		c.m.Delete(key)
+		s.order.Remove(e.element)
+		s.size.Add(-1)
 	}
 	s.mu.Unlock()
 }

--- a/meta_cache_test.go
+++ b/meta_cache_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestMetaCacheShardPadding(t *testing.T) {
-	// The [cacheLinePadSize - 64]byte pad in metaCacheShard hardcodes the
-	// 64-byte payload; this breaks when a field changes that.
-	assert.Equal(t, uintptr(cacheLinePadSize), unsafe.Sizeof(metaCacheShard[string, int32]{}))
+	assert.Equal(t, uintptr(cacheLinePadSize), unsafe.Sizeof(metaCacheShard{}))
 }
 
 func TestMetaCacheBasics(t *testing.T) {
@@ -143,7 +141,7 @@ func TestMetaCacheLruBeatsFifoOnResends(t *testing.T) {
 
 func TestMetaCacheConcurrent(t *testing.T) {
 	// Small capacity keeps every shard full, so promotion, eviction, and
-	// removal all race against read-locked peeks under -race.
+	// removal all race against lock-free peeks under -race.
 	c := newMetaCache[string, int32](64, hashStringKey)
 	keys := make([]string, 512)
 	for i := range keys {


### PR DESCRIPTION
Follow-up to #156 and #159.

## What

- Use one cache-wide `sync.Map` for lock-free steady-state metadata hits.
- Keep the per-shard mutex for insert, removal, eviction, and aged LRU promotion.
- Preserve bounded capacity, retry removal semantics, and cache-line padding.

## Results

Apple M1 Pro, median `ns/op`:

| Benchmark | CPU | Before | After |
| --- | ---: | ---: | ---: |
| `BenchmarkCacheSpanApiParallel` | 1 | 26.05 | 23.47 |
| `BenchmarkCacheSpanApiParallel` | 4 | 97.76 | 6.06 |
| `BenchmarkCacheSpanApiParallel` | 8 | 118.40 | 3.14 |
| `BenchmarkSpanEventParallel` | 4 | 121.10 | 82.08 |
| `BenchmarkSpanEventParallel` | 8 | 139.00 | 82.47 |

The hit path remains allocation-free. The saturated single-thread churn case rises from 25.68 to 43.61 ns/op because writes are more expensive through `sync.Map`; the same benchmark improves from 30.27 to 15.48 ns/op at 4 CPUs and from 31.63 to 15.67 ns/op at 8 CPUs.

## Verification

- `go test . -timeout=90s -skip '^Test_connectCollector_' -count=1`
- `go test -race . -run '^TestMetaCache' -count=1`
- `go vet .`
